### PR TITLE
Add mobile close button for preview

### DIFF
--- a/index.html
+++ b/index.html
@@ -317,7 +317,10 @@
       </div>
     </section>
 
-    <div id="preview-overlay"><div id="media-preview"></div></div>
+    <div id="preview-overlay">
+      <button id="close-preview" aria-label="Close preview">&times;</button>
+      <div id="media-preview"></div>
+    </div>
     <footer class="footer has-background-black has-text-centered has-text-white">
       <div class="content">
         <p>&copy; 2025 Nikita Muromtsev. <a href="https://github.com/nikmedoed" target="_blank" class="has-text-warning">GitHub</a> | <a href="https://www.linkedin.com/in/muromcevn" target="_blank" class="has-text-warning">LinkedIn</a></p>
@@ -328,6 +331,18 @@
 document.addEventListener('DOMContentLoaded', () => {
   const overlay = document.getElementById('preview-overlay');
   const preview = document.getElementById('media-preview');
+  const closeBtn = document.getElementById('close-preview');
+
+  function hidePreview() {
+    overlay.classList.remove('active');
+    preview.innerHTML = '';
+  }
+
+  overlay.addEventListener('click', hidePreview);
+  closeBtn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    hidePreview();
+  });
   document.querySelectorAll('.project-media').forEach(box => {
     const media = box.querySelector('img, video');
     box.addEventListener('mouseenter', () => {
@@ -343,8 +358,7 @@ document.addEventListener('DOMContentLoaded', () => {
       overlay.classList.add('active');
     });
     box.addEventListener('mouseleave', () => {
-      overlay.classList.remove('active');
-      preview.innerHTML = '';
+      hidePreview();
     });
   });
   const burgers = Array.from(document.querySelectorAll('.navbar-burger'));

--- a/style.css
+++ b/style.css
@@ -88,6 +88,19 @@ html, body {
 
 #preview-overlay.active {
   display: flex;
+  pointer-events: auto;
+}
+
+#close-preview {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  font-size: 2rem;
+  color: white;
+  background: none;
+  border: none;
+  cursor: pointer;
+  pointer-events: auto;
 }
 
 .project-media:hover img,


### PR DESCRIPTION
## Summary
- add close button in preview overlay
- let overlay receive clicks and close on button tap

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684fe160dd7c8326b67525d95d11ad48