### PR TITLE
Implement sticky auto-hide header

### DIFF
--- a/experience.html
+++ b/experience.html
@@ -57,20 +57,6 @@
     </div>
   </footer>
 
-  <script>
-    document.addEventListener('DOMContentLoaded', () => {
-      const $navbarBurgers = Array.prototype.slice.call(document.querySelectorAll('.navbar-burger'), 0);
-      if ($navbarBurgers.length > 0) {
-        $navbarBurgers.forEach( el => {
-          el.addEventListener('click', () => {
-            const target = el.dataset.target;
-            const $target = document.getElementById(target);
-            el.classList.toggle('is-active');
-            $target.classList.toggle('is-active');
-          });
-        });
-      }
-    });
-  </script>
+  <script src="header.js"></script>
 </body>
 </html>

--- a/header.js
+++ b/header.js
@@ -1,0 +1,32 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const $navbarBurgers = Array.from(document.querySelectorAll('.navbar-burger'));
+  if ($navbarBurgers.length > 0) {
+    $navbarBurgers.forEach(el => {
+      el.addEventListener('click', () => {
+        const target = el.dataset.target;
+        const $target = document.getElementById(target);
+        el.classList.toggle('is-active');
+        $target.classList.toggle('is-active');
+      });
+    });
+  }
+
+  const navbar = document.querySelector('.navbar');
+  if (!navbar) return;
+  let lastScroll = window.pageYOffset || document.documentElement.scrollTop;
+
+  window.addEventListener('scroll', () => {
+    const current = window.pageYOffset || document.documentElement.scrollTop;
+    if (current <= 0) {
+      navbar.classList.remove('hidden');
+      lastScroll = current;
+      return;
+    }
+    if (current > lastScroll) {
+      navbar.classList.add('hidden');
+    } else if (current < lastScroll) {
+      navbar.classList.remove('hidden');
+    }
+    lastScroll = current;
+  });
+});

--- a/index.html
+++ b/index.html
@@ -281,20 +281,6 @@
       </div>
     </footer>
 
-    <script>
-      document.addEventListener('DOMContentLoaded', () => {
-        const $navbarBurgers = Array.prototype.slice.call(document.querySelectorAll('.navbar-burger'), 0);
-        if ($navbarBurgers.length > 0) {
-          $navbarBurgers.forEach( el => {
-            el.addEventListener('click', () => {
-              const target = el.dataset.target;
-              const $target = document.getElementById(target);
-              el.classList.toggle('is-active');
-              $target.classList.toggle('is-active');
-            });
-          });
-        }
-      });
-    </script>
-</body>
+    <script src="header.js"></script>
+  </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -42,3 +42,15 @@ html, body {
   background-color: currentColor;
   vertical-align: middle;
 }
+
+/* Sticky header that hides on scroll down */
+.navbar {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  transition: transform 0.3s ease;
+}
+
+.navbar.hidden {
+  transform: translateY(-100%);
+}


### PR DESCRIPTION
## Summary
- add sticky header styles
- move navigation script to `header.js`
- use the new script in both pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684fe0c264f08326936d87a906f8dd33