### PR TITLE
Add mobile close button

### DIFF
--- a/index.html
+++ b/index.html
@@ -317,7 +317,10 @@
       </div>
     </section>
 
-    <div id="preview-overlay"><div id="media-preview"></div></div>
+    <div id="preview-overlay">
+      <button id="close-preview" class="delete is-large"></button>
+      <div id="media-preview"></div>
+    </div>
     <footer class="footer has-background-black has-text-centered has-text-white">
       <div class="content">
         <p>&copy; 2025 Nikita Muromtsev. <a href="https://github.com/nikmedoed" target="_blank" class="has-text-warning">GitHub</a> | <a href="https://www.linkedin.com/in/muromcevn" target="_blank" class="has-text-warning">LinkedIn</a></p>
@@ -328,6 +331,10 @@
 document.addEventListener('DOMContentLoaded', () => {
   const overlay = document.getElementById('preview-overlay');
   const preview = document.getElementById('media-preview');
+  overlay.addEventListener('click', () => {
+    overlay.classList.remove('active');
+    preview.innerHTML = '';
+  });
   document.querySelectorAll('.project-media').forEach(box => {
     const media = box.querySelector('img, video');
     box.addEventListener('mouseenter', () => {

--- a/style.css
+++ b/style.css
@@ -88,6 +88,14 @@ html, body {
 
 #preview-overlay.active {
   display: flex;
+  pointer-events: auto;
+}
+
+#close-preview {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  pointer-events: auto;
 }
 
 .project-media:hover img,


### PR DESCRIPTION
## Summary
- add a close icon for preview overlay
- allow clicking overlay to close preview
- adjust styles to enable closing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684fe5126e208326b50bfeee0faf301c