### PR TITLE
Add mobile-friendly media preview

### DIFF
--- a/index.html
+++ b/index.html
@@ -393,6 +393,7 @@
 </section>
 
 <div id="preview-overlay">
+    <button id="close-preview" class="delete is-large" aria-label="close"></button>
     <div id="media-preview"></div>
 </div>
 <footer class="footer has-background-black has-text-centered has-text-white">
@@ -451,24 +452,40 @@
 
         const overlay = document.getElementById('preview-overlay');
         const preview = document.getElementById('media-preview');
+        const closeBtn = document.getElementById('close-preview');
+
+        function show(media) {
+            preview.innerHTML = '';
+            const clone = media.cloneNode(true);
+            if (clone.tagName === 'VIDEO') {
+                clone.muted = true;
+                clone.autoplay = true;
+                clone.loop = true;
+                clone.playsInline = true;
+            }
+            preview.appendChild(clone);
+            overlay.classList.add('active');
+            document.body.classList.add('no-scroll');
+        }
+
+        function hide() {
+            overlay.classList.remove('active');
+            preview.innerHTML = '';
+            document.body.classList.remove('no-scroll');
+        }
+
         document.querySelectorAll('.project-media').forEach(box => {
             const media = box.querySelector('img, video');
-            box.addEventListener('mouseenter', () => {
-                preview.innerHTML = '';
-                const clone = media.cloneNode(true);
-                if (clone.tagName === 'VIDEO') {
-                    clone.muted = true;
-                    clone.autoplay = true;
-                    clone.loop = true;
-                    clone.playsInline = true;
-                }
-                preview.appendChild(clone);
-                overlay.classList.add('active');
+            box.addEventListener('mouseenter', () => show(media));
+            box.addEventListener('click', (e) => {
+                e.preventDefault();
+                show(media);
             });
-            box.addEventListener('mouseleave', () => {
-                overlay.classList.remove('active');
-                preview.innerHTML = '';
-            });
+            box.addEventListener('mouseleave', hide);
+        });
+
+        overlay.addEventListener('click', e => {
+            if (e.target === overlay || e.target === closeBtn) hide();
         });
     });
 

--- a/index.html
+++ b/index.html
@@ -454,7 +454,7 @@
         const preview = document.getElementById('media-preview');
         const closeBtn = document.getElementById('close-preview');
 
-        function show(media) {
+        function show(media, modal = false) {
             preview.innerHTML = '';
             const clone = media.cloneNode(true);
             if (clone.tagName === 'VIDEO') {
@@ -465,11 +465,14 @@
             }
             preview.appendChild(clone);
             overlay.classList.add('active');
-            document.body.classList.add('no-scroll');
+            overlay.classList.toggle('modal', modal);
+            if (modal) {
+                document.body.classList.add('no-scroll');
+            }
         }
 
         function hide() {
-            overlay.classList.remove('active');
+            overlay.classList.remove('active', 'modal');
             preview.innerHTML = '';
             document.body.classList.remove('no-scroll');
         }
@@ -479,9 +482,11 @@
             box.addEventListener('mouseenter', () => show(media));
             box.addEventListener('click', (e) => {
                 e.preventDefault();
-                show(media);
+                show(media, true);
             });
-            box.addEventListener('mouseleave', hide);
+            box.addEventListener('mouseleave', () => {
+                if (!overlay.classList.contains('modal')) hide();
+            });
         });
 
         overlay.addEventListener('click', e => {

--- a/style.css
+++ b/style.css
@@ -89,14 +89,22 @@ html, body {
 
 #preview-overlay.active {
   display: flex;
+}
+
+#preview-overlay.modal {
   pointer-events: auto;
 }
 
 #close-preview {
+  display: none;
   position: absolute;
   top: 1rem;
   right: 1rem;
   pointer-events: auto;
+}
+
+#preview-overlay.modal #close-preview {
+  display: block;
 }
 
 body.no-scroll {

--- a/style.css
+++ b/style.css
@@ -61,6 +61,7 @@ html, body {
   max-width: 90vw;
   max-height: 90vh;
   pointer-events: none;
+  position: relative;
 }
 
 #media-preview img,
@@ -88,6 +89,18 @@ html, body {
 
 #preview-overlay.active {
   display: flex;
+  pointer-events: auto;
+}
+
+#close-preview {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  pointer-events: auto;
+}
+
+body.no-scroll {
+  overflow: hidden;
 }
 
 .project-media:hover img,


### PR DESCRIPTION
## Summary
- show media preview on click/tap
- add close button to preview
- lock scroll and clicks while preview is open

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685575a937ac8326aa5d6589ebcbab63