### PR TITLE
Fix taxonomy layout and style hero buttons

### DIFF
--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -1,0 +1,12 @@
+{{ define "main" }}
+<section class="section">
+  <div class="container">
+    <h1 class="title">{{ .Title }}</h1>
+    <ul>
+    {{ range .Pages }}
+      <li><a href="{{ .Permalink }}">{{ .Title }}</a></li>
+    {{ end }}
+    </ul>
+  </div>
+</section>
+{{ end }}

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -1,0 +1,12 @@
+{{ define "main" }}
+<section class="section">
+  <div class="container">
+    <h1 class="title">{{ .Title }}</h1>
+    <ul>
+    {{ range .Data.Terms.Alphabetical }}
+      <li><a href="{{ .Page.Permalink }}">{{ .Page.Title }} ({{ .Count }})</a></li>
+    {{ end }}
+    </ul>
+  </div>
+</section>
+{{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -27,7 +27,7 @@
     <div class="container">
         <div class="columns is-variable is-6">
             <div class="column">
-                <h2 class="title has-text-centered has-text-danger mb-4">About Me</h2>
+                <h2 class="title has-text-centered has-text-rose mb-4">About Me</h2>
                 <div class="content has-text-left mb-5">
                     <p>👋 Hi, I'm Nikita Muromtsev</p>
                     <p><strong>Full-stack Python &amp; JavaScript Developer | Technical Product Manager | TRIZ Mentor</strong></p>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -27,7 +27,7 @@
     <div class="container">
         <div class="columns is-variable is-6">
             <div class="column">
-                <h2 class="title has-text-centered has-text-rose mb-4">About Me</h2>
+                <h2 class="title has-text-centered has-text-blue mb-4">About Me</h2>
                 <div class="content has-text-left mb-5">
                     <p>👋 Hi, I'm Nikita Muromtsev</p>
                     <p><strong>Full-stack Python &amp; JavaScript Developer | Technical Product Manager | TRIZ Mentor</strong></p>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -27,7 +27,7 @@
     <div class="container">
         <div class="columns is-variable is-6">
             <div class="column">
-                <h2 class="title has-text-centered has-text-blue mb-4">About Me</h2>
+                <h2 class="title has-text-centered has-text-rose mb-4">About Me</h2>
                 <div class="content has-text-left mb-5">
                     <p>👋 Hi, I'm Nikita Muromtsev</p>
                     <p><strong>Full-stack Python &amp; JavaScript Developer | Technical Product Manager | TRIZ Mentor</strong></p>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -2,8 +2,8 @@
 <section class="hero is-medium is-bold gradient-bg">
     <div class="hero-body has-text-centered">
         <p class="title gradient-text mb-4">Muromtsev Nikita: routine automation &amp; awareness tools</p>
-        <p class="subtitle has-text-light hero-subtitle mb-5">Hi there! I'm a Developer × Technical Manager × Mentor.<br><br>Here you'll find tools I couldn’t find decent alternatives to — so I built my own.<br>Now most of them are part of my daily workflow.<br><br>Give them a try — maybe you’ll get excited too.</p>
-        <div class="buttons is-centered mt-5">
+        <p class="subtitle has-text-light hero-subtitle mb-5">Hi there! I'm a Developer × Technical Manager × Mentor.<br><br>Here you'll find tools I couldn’t find decent alternatives to — so I built my own.<br>Now most of them are part of my daily workflow.<br><br><strong>Give them a try — maybe you’ll get excited too.</strong></p>
+        <div class="buttons is-centered mt-5 hero-buttons">
             <a class="button is-info" href="#about">About</a>
             <a class="button is-link" href="#projects">Projects</a>
         </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -2,10 +2,10 @@
 <section class="hero is-medium is-bold gradient-bg">
     <div class="hero-body has-text-centered">
         <p class="title gradient-text mb-4">Muromtsev Nikita: routine automation &amp; awareness tools</p>
-        <p class="subtitle has-text-light hero-subtitle mb-5">Hi there! I'm a Developer × Technical Manager × Mentor.<br><br>Here you'll find tools I couldn’t find decent alternatives to — so I built my own.<br>Now most of them are part of my daily workflow.<br><br><strong>Give them a try — maybe you’ll get excited too.</strong></p>
+        <p class="subtitle has-text-light hero-subtitle mb-5">Hi there! I'm a Developer × Technical Manager × Mentor.<br><br>Here you'll find tools I couldn’t find decent alternatives to — so I built my own.<br>Now most of them are part of my daily workflow.<br><br><span class="tagline-accent">Give them a try — maybe you’ll get excited too.</span></p>
         <div class="buttons is-centered mt-5 hero-buttons">
-            <a class="button is-info" href="#about">About</a>
-            <a class="button is-link" href="#projects">Projects</a>
+            <a class="button about-btn" href="#about">About</a>
+            <a class="button projects-btn" href="#projects">Projects</a>
         </div>
     </div>
 </section>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -301,7 +301,7 @@ body.no-scroll {
 .hero-buttons .about-btn {
   background-color: var(--c-rose);
   border-color: var(--c-rose);
-  color: #fff;
+  color: #000;
 }
 .hero-buttons .projects-btn {
   background-color: var(--c-yellow);

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -278,6 +278,13 @@ body.no-scroll {
   color: #fff;
 }
 
+/* Hero buttons use theme lime color */
+.hero-buttons .button {
+  background-color: #c6db09;
+  border-color: #c6db09;
+  color: #000;
+}
+
 #contact-form .button.is-link {
   background-color: #c6db09;
   border-color: #c6db09;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -28,6 +28,12 @@ html, body {
   margin-right: auto;
 }
 
+/* Subtle highlight for hero tagline */
+.tagline-accent {
+  color: #c6db09;
+  font-style: italic;
+}
+
 .project-card {
   display: flex;
   flex-direction: column;
@@ -278,10 +284,18 @@ body.no-scroll {
   color: #fff;
 }
 
-/* Hero buttons use theme lime color */
+/* Hero buttons use different theme colors but equal width */
 .hero-buttons .button {
-  background-color: #c6db09;
-  border-color: #c6db09;
+  width: 9rem;
+}
+.hero-buttons .about-btn {
+  background-color: var(--c-blue);
+  border-color: var(--c-blue);
+  color: #fff;
+}
+.hero-buttons .projects-btn {
+  background-color: var(--c-yellow);
+  border-color: var(--c-yellow);
   color: #000;
 }
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -299,8 +299,8 @@ body.no-scroll {
   width: 9rem;
 }
 .hero-buttons .about-btn {
-  background-color: var(--c-blue);
-  border-color: var(--c-blue);
+  background-color: var(--c-rose);
+  border-color: var(--c-rose);
   color: #fff;
 }
 .hero-buttons .projects-btn {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -4,7 +4,6 @@
   --c-violet: #371542;
   --c-blue: #194d91;
   --c-yellow: #fffe45;
-  --c-rose: #ed7086;
 }
 
 html, body {
@@ -32,13 +31,13 @@ html, body {
 
 /* Subtle highlight for hero tagline */
 .tagline-accent {
-  color: var(--c-rose);
+  color: var(--c-yellow);
   font-style: italic;
 }
 
-/* Utility color class for About section and accents */
-.has-text-rose {
-  color: var(--c-rose) !important;
+/* Utility color classes for section accents */
+.has-text-blue {
+  color: var(--c-blue) !important;
 }
 
 .project-card {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,8 +1,10 @@
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap&subset=cyrillic");
 :root {
   --c-pink: #fa33fa;
   --c-violet: #371542;
   --c-blue: #194d91;
   --c-yellow: #fffe45;
+  --c-rose: #ed7086;
 }
 
 html, body {
@@ -30,8 +32,13 @@ html, body {
 
 /* Subtle highlight for hero tagline */
 .tagline-accent {
-  color: #c6db09;
+  color: var(--c-rose);
   font-style: italic;
+}
+
+/* Utility color class for About section and accents */
+.has-text-rose {
+  color: var(--c-rose) !important;
 }
 
 .project-card {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -4,6 +4,7 @@
   --c-violet: #371542;
   --c-blue: #194d91;
   --c-yellow: #fffe45;
+  --c-rose: #ed7086;
 }
 
 html, body {
@@ -38,6 +39,9 @@ html, body {
 /* Utility color classes for section accents */
 .has-text-blue {
   color: var(--c-blue) !important;
+}
+.has-text-rose {
+  color: var(--c-rose) !important;
 }
 
 .project-card {


### PR DESCRIPTION
## Summary
- fix missing layouts for taxonomy pages
- emphasize tagline in hero section
- style hero buttons with theme color

## Testing
- `hugo --minify`

------
https://chatgpt.com/codex/tasks/task_e_68581cc8ca388326a5f4426d6e9a33a9