### PR TITLE
Fix scroll listener for modern browsers

### DIFF
--- a/static/js/script.js
+++ b/static/js/script.js
@@ -39,10 +39,10 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     const navbar = document.querySelector('.navbar');
-    let lastScroll = window.pageYOffset || document.documentElement.scrollTop;
+    let lastScroll = window.scrollY;
     if (navbar) {
         window.addEventListener('scroll', () => {
-            const current = window.pageYOffset || document.documentElement.scrollTop;
+            const current = window.scrollY;
             if (current <= 0) {
                 navbar.classList.remove('hidden');
                 lastScroll = current;


### PR DESCRIPTION
## Summary
- clean up scroll logic
- remove deprecated `pageYOffset`

## Testing
- `hugo --minify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68581fbdcdbc8326b28e73f113316077