### PR TITLE
Add two-tone background for about section

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -25,8 +25,8 @@
 
 <section class="section has-background-link-dark has-text-white" id="about">
     <div class="container">
-        <div class="columns is-variable is-6">
-            <div class="column">
+        <div class="columns is-variable is-6 is-gapless">
+            <div class="column about-column">
                 <h2 class="title has-text-centered has-text-rose mb-4">About Me</h2>
                 <div class="content has-text-left mb-5">
                     <p>👋 Hi, I'm Nikita Muromtsev</p>
@@ -44,7 +44,7 @@
                     <p>I'm always open to ideas, suggestions for improvement, and contributions — whether through code or financial support.</p>
                 </div>
             </div>
-            <div class="column">
+            <div class="column support-column">
                 <h2 class="title has-text-centered has-text-warning mb-4">Support My Work</h2>
                 <div class="box support-box has-text-white has-text-centered">
                     <p>If you appreciate my projects and want to support me</p>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -322,3 +322,14 @@ body.no-scroll {
   transform: translateX(-50%);
   z-index: 1000;
 }
+
+/* Split background colors for About and Support columns */
+.about-column {
+  background-color: var(--c-violet);
+  padding: 2rem;
+}
+
+.support-column {
+  background-color: var(--c-blue);
+  padding: 2rem;
+}


### PR DESCRIPTION
## Summary
- split the about/support row into two color columns using theme palette
- style `.about-column` with violet and `.support-column` with blue

## Testing
- `hugo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858473cddf88326bc1e71cd818f6ec8