### PR TITLE
Fix project card icon spacing

### DIFF
--- a/layouts/partials/project-card.html
+++ b/layouts/partials/project-card.html
@@ -15,7 +15,7 @@
         {{ end }}
         <div class="card-content">
             <p class="title is-5">
-                <span class="icon mr-2">
+                <span class="icon">
                     {{ if eq .icon "tm-icon" }}<span aria-label="Tampermonkey" class="tm-icon" role="img"></span>{{ else }}<i class="{{ .icon }}"></i>{{ end }}
                 </span>
                 <a href="{{ .repo }}" target="_blank">{{ .title }}</a>

--- a/layouts/partials/project-card.html
+++ b/layouts/partials/project-card.html
@@ -15,7 +15,7 @@
         {{ end }}
         <div class="card-content">
             <p class="title is-5">
-                <span class="icon">
+                <span class="icon mr-2">
                     {{ if eq .icon "tm-icon" }}<span aria-label="Tampermonkey" class="tm-icon" role="img"></span>{{ else }}<i class="{{ .icon }}"></i>{{ end }}
                 </span>
                 <a href="{{ .repo }}" target="_blank">{{ .title }}</a>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -56,6 +56,9 @@ html, body {
 .project-card .card-content {
   flex-grow: 1;
 }
+.project-card .title .icon {
+  margin-right: 0.5em;
+}
 
 .project-media {
   position: relative;


### PR DESCRIPTION
## Summary
- add right margin to project card icons so text doesn't cling to icons

## Testing
- `hugo`

------
https://chatgpt.com/codex/tasks/task_e_685859d36f908326a133880770a87984