### PR TITLE
Fix project card grid

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -55,6 +55,12 @@ html, body {
 }
 .project-card .card-content {
   flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.project-card .card-content .tags {
+  margin-top: auto;
 }
 
 .project-media {


### PR DESCRIPTION
## Summary
- align project card tags across the grid so they start on the same line

## Testing
- `hugo`


------
https://chatgpt.com/codex/tasks/task_e_687772045ebc832683c5cc1a684a14dc