### PR TITLE
Fix Hugo build warnings by enabling raw HTML

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,3 +1,8 @@
 baseURL = "https://nikmedoed.github.io/"
 languageCode = "en-us"
 title = "Nikita Muromtsev"
+
+[markup]
+  [markup.goldmark]
+    [markup.goldmark.renderer]
+      unsafe = true


### PR DESCRIPTION
## Summary
- turn on unsafe rendering for Goldmark to allow raw HTML

## Testing
- `hugo --verbose`

------
https://chatgpt.com/codex/tasks/task_e_687771ecdb408326b04f79c5183037d5