### PR TITLE
Fix playback speed extension conflict

### DIFF
--- a/layouts/partials/project-card.html
+++ b/layouts/partials/project-card.html
@@ -4,7 +4,7 @@
         <div class="card-image">
             <figure class="project-media{{ if not (strings.HasSuffix .media ".mp4") }} contain{{ end }}">
                 {{ if (strings.HasSuffix .media ".mp4") }}
-                <video autoplay loop muted playsinline src="/media/{{ .media }}"></video>
+                <video class="vc-cancelled" autoplay loop muted playsinline src="/media/{{ .media }}"></video>
                 {{ else }}
                 <img alt="{{ .title }} screenshot" src="/media/{{ .media }}">
                 {{ end }}


### PR DESCRIPTION
## Summary
- avoid interfering with the "YouTube Playback Speed Control" extension by marking page videos as `vc-cancelled`

## Testing
- `hugo --minify`

------
https://chatgpt.com/codex/tasks/task_e_6877a4d4e3ac8326a1a3282129fc6e32