### PR TITLE
Fix wallet address wrapping in support section

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -255,6 +255,9 @@ body.no-scroll {
 .wallets .button {
   vertical-align: middle;
 }
+.wallets span {
+  word-break: break-all;
+}
 
 .telegram-link {
   color: #27a7e7;


### PR DESCRIPTION
## Summary
- ensure crypto wallet addresses wrap within the support block

## Testing
- `hugo`

------
https://chatgpt.com/codex/tasks/task_e_6877c178ecc083268142e82601f15306