### PR TITLE
Fix strong text color in dark blocks

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -250,10 +250,15 @@ body.no-scroll {
   background-color: #421537;
 }
 
+/* Ensure strong text inside dark boxes remains legible */
+.has-text-white strong {
+  color: inherit;
+}
+
 .wallets strong,
 .wallets span,
 .wallets .button {
-  vertical-align: middle;
+    vertical-align: middle;
 }
 .wallets span {
   word-break: break-all;


### PR DESCRIPTION
## Summary
- ensure text inside dark blocks remains visible by inheriting color for `strong`

## Testing
- `hugo --minify`

------
https://chatgpt.com/codex/tasks/task_e_6877e60f0e448326ad77f964d3c572de