### PR TITLE
Fix tag color mapping

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -56,6 +56,10 @@
 
 <div id="notification-container" class="notification-container"></div>
 
+<script id="tag-colors-data" type="application/json">
+{{- $.Site.Data.tag_colors | jsonify -}}
+</script>
+
 {{ block "main" . }}{{ end }}
 
 <footer class="footer has-background-black has-text-centered has-text-white">

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -7,6 +7,9 @@ document.addEventListener('DOMContentLoaded', () => {
         en: {all: 'All', sent: 'Message sent!', fail: 'Failed to send message.'},
         ru: {all: 'Все', sent: 'Сообщение отправлено!', fail: 'Не удалось отправить сообщение.'}
     };
+
+    const tagColorsEl = document.getElementById('tag-colors-data');
+    const tagColors = tagColorsEl ? JSON.parse(tagColorsEl.textContent) : {};
     if (!storedLang) {
         const navLang = (navigator.languages && navigator.languages[0]) || navigator.language || '';
         if (navLang.startsWith('ru') && currentLang === 'en') {
@@ -93,13 +96,14 @@ document.addEventListener('DOMContentLoaded', () => {
     const counts = {};
     const colors = {};
     cards.forEach(card => {
-        const tagEls = card.querySelectorAll('.tags .tag');
+        const tagEls = card.querySelectorAll('.project-tag');
         const tags = Array.from(tagEls).map(t => {
             const text = t.textContent.trim();
+            const color = tagColors[text] || 'is-light';
             if (!colors[text]) {
-                const cls = Array.from(t.classList).filter(c => c !== 'tag').join(' ');
-                colors[text] = cls;
+                colors[text] = color;
             }
+            t.classList.add(color);
             counts[text] = (counts[text] || 0) + 1;
             return text;
         });
@@ -112,7 +116,8 @@ document.addEventListener('DOMContentLoaded', () => {
         filterBar.innerHTML = `<span class="tag filter-tag is-dark" data-tech="all">${allLabel}</span>`;
         Object.keys(counts).sort((a, b) => counts[b] - counts[a]).forEach(t => {
             const s = document.createElement('span');
-            s.className = `tag filter-tag has-text-dark ${colors[t]}`;
+            const color = colors[t] || tagColors[t] || 'is-light';
+            s.className = `tag filter-tag has-text-dark ${color}`;
             s.dataset.tech = t;
             s.textContent = t;
             filterBar.appendChild(s);


### PR DESCRIPTION
## Summary
- expose `tag_colors` site data for JS
- colorize project tags and filter bar using the dictionary

## Testing
- `hugo -s . -d /tmp/site`

------
https://chatgpt.com/codex/tasks/task_e_6877e5ba86a083268f2fd61d326dd935