### PR TITLE
Fix tag color lookup

### DIFF
--- a/layouts/partials/project-card.html
+++ b/layouts/partials/project-card.html
@@ -29,7 +29,7 @@
             <p class="content">{{ $description }}</p>
             <div class="tags">
                 {{ range $p.tags }}
-                {{ $color := index $.Site.Data.tag_colors . | default "is-light" }}
+                {{ $color := index site.Data.tag_colors . | default "is-light" }}
                 <span class="tag {{ $color }} is-light has-text-dark project-tag" data-tech="{{ . }}">{{ . }}</span>
                 {{ end }}
             </div>


### PR DESCRIPTION
## Summary
- use global `site` variable so partial can read `data/tag_colors.yaml`

## Testing
- `hugo`

------
https://chatgpt.com/codex/tasks/task_e_6877ec34cc1083268a07e294550d851a