### PR TITLE
Fix hero buttons layout on mobile

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -3,7 +3,7 @@
     <div class="hero-body has-text-centered">
         <h1 class="title gradient-text mb-4">{{ i18n "heroTitle" }}</h1>
         <p class="subtitle has-text-light hero-subtitle mb-5">{{ i18n "heroSubtitle" | safeHTML }}</p>
-        <div class="buttons is-centered mt-5 hero-buttons">
+        <div class="buttons is-centered mt-5 hero-buttons is-flex-wrap-nowrap">
             <a class="button about-btn" href="#about">{{ i18n "heroAboutBtn" }}</a>
             <a class="button projects-btn" href="#projects">{{ i18n "heroProjectsBtn" }}</a>
         </div>


### PR DESCRIPTION
## Summary
- keep hero buttons on the same line on small screens by preventing flex wrap

## Testing
- `hugo -D`

------
https://chatgpt.com/codex/tasks/task_e_6877eec5bbe083269b9556a2d1bc0468