### PR TITLE
Fix icon spacing in project cards

### DIFF
--- a/layouts/partials/project-card.html
+++ b/layouts/partials/project-card.html
@@ -23,9 +23,7 @@
                 <span class="icon">
                     {{ if eq $p.icon "tm-icon" }}<span aria-label="Tampermonkey" class="tm-icon" role="img"></span>{{ else }}<i class="{{ $p.icon }}"></i>{{ end }}
                 </span>
-                <span>
-                    <a href="{{ $p.repo }}" target="_blank">{{ $title }}</a>
-                </span>
+                <a href="{{ $p.repo }}" target="_blank">{{ $title }}</a>
             </p>
             <p class="subtitle is-6">{{ $subtitle }}</p>
             <p class="content">{{ $description }}</p>

--- a/layouts/partials/project-card.html
+++ b/layouts/partials/project-card.html
@@ -19,11 +19,13 @@
         <div class="card-image"></div>
         {{ end }}
         <div class="card-content">
-            <p class="title is-5">
+            <p class="title is-5 icon-text">
                 <span class="icon">
                     {{ if eq $p.icon "tm-icon" }}<span aria-label="Tampermonkey" class="tm-icon" role="img"></span>{{ else }}<i class="{{ $p.icon }}"></i>{{ end }}
                 </span>
-                <a href="{{ $p.repo }}" target="_blank">{{ $title }}</a>
+                <span>
+                    <a href="{{ $p.repo }}" target="_blank">{{ $title }}</a>
+                </span>
             </p>
             <p class="subtitle is-6">{{ $subtitle }}</p>
             <p class="content">{{ $description }}</p>


### PR DESCRIPTION
## Summary
- use Bulma `icon-text` in project cards to enforce spacing

## Testing
- `hugo --minify`

------
https://chatgpt.com/codex/tasks/task_e_6877f769e9288326994dcd64a916b2fc