### PR TITLE
Add analytics counters with event tracking

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -22,6 +22,31 @@
     <link rel="shortcut icon" href="/favicon/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/favicon/apple-touch-icon.png">
     <link rel="manifest" href="/favicon/site.webmanifest">
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-LSK6GYSNTQ"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-LSK6GYSNTQ');
+    </script>
+    <!-- Yandex.Metrika counter -->
+    <script type="text/javascript">
+       (function(m,e,t,r,i,k,a){m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
+       m[i].l=1*new Date();
+       for (var j = 0; j < document.scripts.length; j++) {if (document.scripts[j].src === r) { return; }}
+       k=e.createElement(t),a=e.getElementsByTagName(t)[0],k.async=1,k.src=r,a.parentNode.insertBefore(k,a)})
+       (window, document, "script", "https://mc.yandex.ru/metrika/tag.js", "ym");
+
+       ym(103383232, "init", {
+            clickmap:true,
+            trackLinks:true,
+            accurateTrackBounce:true
+       });
+    </script>
+    <noscript><div><img src="https://mc.yandex.ru/watch/103383232" style="position:absolute; left:-9999px;" alt="" /></div></noscript>
+    <!-- /Yandex.Metrika counter -->
 </head>
 <body>
 <nav class="navbar is-dark" role="navigation" aria-label="main navigation">

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -1,4 +1,12 @@
 document.addEventListener('DOMContentLoaded', () => {
+    function trackEvent(name, label = '') {
+        if (typeof gtag === 'function') {
+            gtag('event', name, { event_category: 'interaction', event_label: label });
+        }
+        if (typeof ym === 'function') {
+            ym(103383232, 'reachGoal', name);
+        }
+    }
     const currentLang = document.documentElement.lang;
     const baseAttr = document.documentElement.dataset.base || '/';
     const basePath = baseAttr.replace(/\/$/, '');
@@ -150,6 +158,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const tgt = e.target.closest('.filter-tag');
             if (!tgt) return;
             const tech = tgt.dataset.tech;
+            trackEvent('tag_click', tech);
             filterBar.querySelectorAll('.filter-tag').forEach(tag => tag.classList.remove('is-dark'));
             tgt.classList.add('is-dark');
             cards.forEach(c => {
@@ -215,6 +224,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     document.querySelectorAll('.copy-btn').forEach(btn => {
         btn.addEventListener('click', () => {
+            trackEvent('support_click', 'copy');
             const text = btn.dataset.clipboardText;
             if (!text) return;
             navigator.clipboard.writeText(text).then(() => {
@@ -224,6 +234,18 @@ document.addEventListener('DOMContentLoaded', () => {
                     if (icon) icon.className = 'fas fa-copy';
                 }, 1500);
             });
+        });
+    });
+
+    document.querySelectorAll('.support-box .buttons .button').forEach(btn => {
+        btn.addEventListener('click', () => {
+            trackEvent('support_click', btn.textContent.trim());
+        });
+    });
+
+    document.querySelectorAll('a[href*="t.me"]').forEach(link => {
+        link.addEventListener('click', () => {
+            trackEvent('telegram_click');
         });
     });
 
@@ -250,6 +272,7 @@ document.addEventListener('DOMContentLoaded', () => {
             document.documentElement.classList.remove('is-clipped');
         };
         emailBtn.addEventListener('click', () => {
+            trackEvent('email_click');
             emailModal.classList.add('is-active');
             document.documentElement.classList.add('is-clipped');
         });


### PR DESCRIPTION
## Summary
- embed Google Analytics and Yandex.Metrika in the base template
- add tracking helper in main script
- log clicks on tags, support buttons, email open and Telegram links

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687a9307fa7c832691ddf3b78490b7a4