### PR TITLE
Refine cat card layout

### DIFF
--- a/layouts/partials/cat-card.html
+++ b/layouts/partials/cat-card.html
@@ -2,46 +2,39 @@
 {{ $lang := .lang }}
 {{ $cats := .cats }}
 <div class="column is-12-mobile is-6-tablet is-4-desktop">
-  <div class="box cat-card" id="cat-{{ $cat.id }}" data-year="{{ substr $cat.birth 0 4 }}" data-birth="{{ $cat.birth }}" data-sterilized="{{ if $cat.sterilized }}yes{{ else }}no{{ end }}" data-treatment="{{ if (index $cat.treatment $lang) }}yes{{ else }}no{{ end }}">
-    <article class="media">
-      <figure class="media-left">
-        <p class="image is-128x128">
-          <img class="cat-photo" src="{{ $cat.photo }}" alt="{{ index $cat.name $lang }}">
-        </p>
-      </figure>
-      <div class="media-content">
-        <p class="title is-5">{{ index $cat.name $lang }}</p>
-        <p class="subtitle is-6">{{ index $cat.description $lang }}</p>
-        <p class="is-size-7">{{ i18n "age" }}: <span class="cat-age"></span></p>
-        <div class="tags mt-2">
-          <span class="tag {{ if $cat.sterilized }}is-success{{ else }}is-warning{{ end }}">
-            {{ if $cat.sterilized }}{{ i18n "filterSterilized" }}{{ else }}{{ i18n "filterNotSterilized" }}{{ end }}
-          </span>
-          {{ $t := index $cat.treatment $lang }}
-          {{ if $t }}<span class="tag is-danger">{{ $t }}</span>{{ end }}
-          <span class="tag is-light">{{ i18n (printf "gender%s" (title $cat.gender)) }}</span>
-          <span class="tag is-link cat-category"></span>
-          {{ range $id := $cat.parents }}
-            {{ $p := index (where $cats "id" $id) 0 }}
-            {{ if $p }}
-              {{ $key := cond (eq $p.gender "female") "mother" "father" }}
-              <span class="tag is-info cat-relative" data-target="cat-{{ $p.id }}">{{ i18n $key }}: {{ index $p.name $lang }}</span>
-            {{ end }}
-          {{ end }}
-          {{ $children := where $cats "parents" "intersect" (slice $cat.id) }}
-          {{ range $child := $children }}
-            {{ $key := cond (eq $child.gender "female") "daughter" "son" }}
-            <span class="tag is-info cat-relative" data-target="cat-{{ $child.id }}">{{ i18n $key }}: {{ index $child.name $lang }}</span>
-          {{ end }}
-          {{ if $cat.parents }}
-            {{ $siblings := uniq (where (where $cats "id" "ne" $cat.id) "parents" "intersect" $cat.parents) }}
-            {{ range $sib := $siblings }}
-              {{ $key := cond (eq $sib.gender "female") "sister" "brother" }}
-              <span class="tag is-info cat-relative" data-target="cat-{{ $sib.id }}">{{ i18n $key }}: {{ index $sib.name $lang }}</span>
-            {{ end }}
-          {{ end }}
-        </div>
-      </div>
-    </article>
+  <div class="box cat-card has-text-centered" id="cat-{{ $cat.id }}" data-year="{{ substr $cat.birth 0 4 }}" data-birth="{{ $cat.birth }}" data-sterilized="{{ if $cat.sterilized }}yes{{ else }}no{{ end }}" data-treatment="{{ if (index $cat.treatment $lang) }}yes{{ else }}no{{ end }}">
+    <figure class="image is-256x256 is-inline-block">
+      <img class="cat-photo" src="{{ $cat.photo }}" alt="{{ index $cat.name $lang }}">
+    </figure>
+    <p class="title is-4 mb-0">{{ index $cat.name $lang }}</p>
+    <p class="is-size-6 mt-0 mb-3">{{ i18n "age" }}: <span class="cat-age"></span></p>
+    <p class="subtitle is-6 mb-2">{{ index $cat.description $lang }}</p>
+    <div class="tags is-centered mt-2">
+      <span class="tag {{ if $cat.sterilized }}is-success{{ else }}is-warning{{ end }}">
+        {{ if $cat.sterilized }}{{ i18n "filterSterilized" }}{{ else }}{{ i18n "filterNotSterilized" }}{{ end }}
+      </span>
+      {{ $t := index $cat.treatment $lang }}
+      {{ if $t }}<span class="tag is-danger">{{ $t }}</span>{{ end }}
+      <span class="tag is-light">{{ i18n (printf "gender%s" (title $cat.gender)) }}</span>
+      {{ range $id := $cat.parents }}
+        {{ $p := index (where $cats "id" $id) 0 }}
+        {{ if $p }}
+          {{ $key := cond (eq $p.gender "female") "mother" "father" }}
+          <span class="tag is-info cat-relative" data-target="cat-{{ $p.id }}">{{ i18n $key }}: {{ index $p.name $lang }}</span>
+        {{ end }}
+      {{ end }}
+      {{ $children := where $cats "parents" "intersect" (slice $cat.id) }}
+      {{ range $child := $children }}
+        {{ $key := cond (eq $child.gender "female") "daughter" "son" }}
+        <span class="tag is-info cat-relative" data-target="cat-{{ $child.id }}">{{ i18n $key }}: {{ index $child.name $lang }}</span>
+      {{ end }}
+      {{ if $cat.parents }}
+        {{ $siblings := uniq (where (where $cats "id" "ne" $cat.id) "parents" "intersect" $cat.parents) }}
+        {{ range $sib := $siblings }}
+          {{ $key := cond (eq $sib.gender "female") "sister" "brother" }}
+          <span class="tag is-info cat-relative" data-target="cat-{{ $sib.id }}">{{ i18n $key }}: {{ index $sib.name $lang }}</span>
+        {{ end }}
+      {{ end }}
+    </div>
   </div>
 </div>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -113,6 +113,9 @@ html, body {
   padding: 1.5rem;
   border-radius: 8px;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 .cat-card:hover {
   transform: translateY(-4px);
@@ -122,8 +125,8 @@ html, body {
   margin-top: 0.5rem;
 }
 .cat-card img.cat-photo {
-  width: 128px;
-  height: 128px;
+  width: 256px;
+  height: 256px;
   border-radius: 50%;
   object-fit: cover;
 }

--- a/static/js/cats.js
+++ b/static/js/cats.js
@@ -57,13 +57,11 @@ document.addEventListener('DOMContentLoaded', () => {
         en: {y: 'y', m: 'm', kitten: 'Kitten', teen: 'Teen', adult: 'Adult'},
         ru: {y: 'г.', m: 'мес.', kitten: 'Котёнок', teen: 'Подросток', adult: 'Взрослый'}
     };
-    const catClasses = {kitten: 'is-primary', teen: 'is-info', adult: 'is-dark'};
 
     cards.forEach(card => {
         const birth = card.dataset.birth;
         const ageSpan = card.querySelector('.cat-age');
-        const categorySpan = card.querySelector('.cat-category');
-        if (birth && ageSpan && categorySpan) {
+        if (birth && ageSpan) {
             const [year, month] = birth.split('-').map(Number);
             const now = new Date();
             let y = now.getFullYear() - year;
@@ -77,8 +75,7 @@ document.addEventListener('DOMContentLoaded', () => {
             let category = 'adult';
             if (months < 4) category = 'kitten';
             else if (months < 12) category = 'teen';
-            categorySpan.textContent = labels[lang][category];
-            categorySpan.classList.add(catClasses[category]);
+            card.dataset.category = category;
         }
     });
 


### PR DESCRIPTION
## Summary
- Display cat cards vertically with centered content and larger photos
- Improve spacing for name, age, description, and tags
- Remove age category tag from card display

## Testing
- `hugo`

------
https://chatgpt.com/codex/tasks/task_e_68a58cfef7cc8326915585ad6f229b1b