### PR TITLE
Support multiple photos per cat

### DIFF
--- a/content/cat-gallery.en.md
+++ b/content/cat-gallery.en.md
@@ -1,0 +1,5 @@
+---
+title: "Cat Gallery"
+layout: cat-gallery
+url: cat-gallery
+---

--- a/content/cat-gallery.ru.md
+++ b/content/cat-gallery.ru.md
@@ -1,0 +1,5 @@
+---
+title: "Галерея"
+layout: cat-gallery
+url: cat-gallery
+---

--- a/data/cats.yaml
+++ b/data/cats.yaml
@@ -3,7 +3,22 @@
     en: Barsik
     ru: Барсик
   gender: male
-  photo: https://animals-travel.ru/upload/medialibrary/693/693042430520412f7d94b7a6886799c3.jpg
+  photos:
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716326/20250805_173757-16e62f57.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716321/20250805_173057-fc30a8a1.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716334/20250805_175105-29415ac3.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716332/20250805_174349-123734ab.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716331/20250805_174300-83274aa6.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716327/20250805_173928-aa612e1c.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716325/20250805_173745-7f8ac79c.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716324/20250805_173546-fddb06ee.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716342/20250812_161948-6a107c1a.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716322/20250805_173155-b981b9c5.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716321/20250805_173057-fc30a8a1.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716324/20250805_173546-fddb06ee.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716330/20250805_174202-c0838213.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716331/20250805_174300-83274aa6.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716321/20250805_173057-fc30a8a1.jpg
   description:
     en: Playful striped kitten who explores every corner of the yard. He chases each falling leaf, climbs the nearest fence, and makes friends with anyone offering a pat. Friendly with people and other cats alike, he quickly becomes the center of attention. Despite his energy, he loves curling up for a nap on warm laps.
     ru: Игривый полосатый котёнок, который исследует каждый угол двора. Гоняется за каждым падающим листиком, забирается на ближайший забор и дружит со всеми, кто готов его погладить. Легко ладит с людьми и другими кошками, быстро оказывается в центре внимания. Несмотря на энергию, любит свернуться клубочком на тёплых коленях.
@@ -23,7 +38,20 @@
     en: Murka
     ru: Мурка
   gender: female
-  photo: https://animals-travel.ru/upload/medialibrary/693/693042430520412f7d94b7a6886799c3.jpg
+  photos:
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716329/20250805_174135-2e948b59.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716341/20250812_161755-d45d6e1c.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716331/20250805_174300-83274aa6.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716342/20250812_162001-b04ea281.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716334/20250805_175105-29415ac3.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716320/20250805_173030-d1287ba6.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716328/20250805_174055-2b421a59.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716342/20250812_161948-6a107c1a.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716337/20250805_180039-29eee4ec.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716334/20250805_175105-29415ac3.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716327/20250805_174025-d70b8d98.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716330/20250805_174202-c0838213.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716337/20250805_180039-29eee4ec.jpg
   description:
     en: Calm and affectionate, Murka happily watches over the younger cats in the yard. She enjoys long naps by the window and greets visitors with a gentle purr. In the evenings she curls up beside her friends, keeping them warm. Beneath her soft demeanor hides a playful spirit that awakens whenever a toy rolls by.
     ru: Спокойная и ласковая, Мурка с удовольствием присматривает за младшими котятами во дворе. Любит подолгу дремать у окна и встречает гостей тихим мурлыканьем. По вечерам устраивается рядом с друзьями, согревая их своим теплом. За мягким нравом скрывается игривый характер, который просыпается, стоит покатиться игрушке.
@@ -41,7 +69,13 @@
     en: Snezhok
     ru: Снежок
   gender: male
-  photo: https://animals-travel.ru/upload/medialibrary/693/693042430520412f7d94b7a6886799c3.jpg
+  photos:
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716324/20250805_173546-fddb06ee.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716339/20250805_180353-fd742df5.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716325/20250805_173745-7f8ac79c.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716337/20250805_180114-1640044d.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716337/20250805_180114-1640044d.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716333/20250805_174825-ccea7193.jpg
   description:
     en: Snezhok is a fluffy white tom who loves to nap in the sun and watch birds from the fence. He prefers peaceful mornings and stretches lazily before joining others for breakfast. When the yard quiets down, he patrols his territory with dignity. On chilly nights he seeks a cozy box and dreams of endless summer.
     ru: Снежок — пушистый белый кот, который любит греться на солнце и наблюдать за птицами с забора. Предпочитает спокойные утра и лениво потягивается, прежде чем присоединиться к остальным на завтрак. Когда двор затихает, обходит свои владения с достоинством. В прохладные вечера ищет уютную коробку и мечтает о бесконечном лете.
@@ -59,7 +93,12 @@
     en: Ryzhik
     ru: Рыжик
   gender: male
-  photo: https://animals-travel.ru/upload/medialibrary/693/693042430520412f7d94b7a6886799c3.jpg
+  photos:
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716343/20250812_162133-6a45fb46.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716326/20250805_173757-16e62f57.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716339/20250805_180353-fd742df5.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716324/20250805_173546-fddb06ee.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716334/20250805_175638-6f537287.jpg
   description:
     en: Ginger tom who wandered into the yard last winter. He meows loudly for attention and follows anyone carrying food. Though wary at first, he now trusts the caretakers and enjoys gentle head scratches. Recently he has shown great patience while recovering from an ear infection.
     ru: Рыжий кот, появившийся во дворе прошлой зимой. Громко мяукает, требуя внимания, и следует за каждым, кто несёт еду. Сначала был осторожен, но теперь доверяет опекунам и любит, когда его гладят по голове. Недавно проявил большое терпение, восстанавливаясь после ушной инфекции.
@@ -77,7 +116,22 @@
     en: Luna
     ru: Луна
   gender: female
-  photo: https://animals-travel.ru/upload/medialibrary/693/693042430520412f7d94b7a6886799c3.jpg
+  photos:
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716338/20250805_180342-581d9c30.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716329/20250805_174135-2e948b59.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716324/20250805_173325-f7084425.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716322/20250805_173155-b981b9c5.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716331/20250805_174300-83274aa6.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716334/20250805_175638-6f537287.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716324/20250805_173546-fddb06ee.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716331/20250805_174300-83274aa6.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716325/20250805_173745-7f8ac79c.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716339/20250805_180353-fd742df5.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716334/20250805_175105-29415ac3.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716343/20250812_162133-6a45fb46.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716338/20250805_180342-581d9c30.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716328/20250805_174055-2b421a59.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716338/20250805_180342-581d9c30.jpg
   description:
     en: Graceful gray queen with curious bright eyes. Luna likes to perch on the fence and observe the neighborhood like a quiet guardian. She befriends newcomers and often brings them to the feeding spot. After her evening patrol she settles down, purring softly as the street grows quiet.
     ru: Стройная серая кошка с любопытными яркими глазами. Луна любит сидеть на заборе и наблюдать за окрестностями, словно тихий хранитель. Дружелюбна к новым гостям и часто приводит их к миске с едой. После вечернего обхода устраивается поудобнее и тихо мурлычет, когда улица затихает.
@@ -95,7 +149,17 @@
     en: Timka
     ru: Тимка
   gender: male
-  photo: https://animals-travel.ru/upload/medialibrary/693/693042430520412f7d94b7a6886799c3.jpg
+  photos:
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716330/20250805_174202-c0838213.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716334/20250805_175105-29415ac3.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716324/20250805_173325-f7084425.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716328/20250805_174055-2b421a59.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716332/20250805_174349-123734ab.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716328/20250805_174055-2b421a59.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716343/20250812_162133-6a45fb46.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716339/20250805_180353-fd742df5.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716334/20250805_175105-29415ac3.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716331/20250805_174300-83274aa6.jpg
   description:
     en: Tiny ball of energy who can't stay still for a second. Timka wrestles with any piece of string and tumbles over his own paws. He shadows his mother on adventures and learns to climb after his father. When exhausted he collapses into deep sleep, dreaming of new games.
     ru: Маленький комочек энергии, который не может усидеть на месте ни секунды. Тимка борется с любой верёвочкой и спотыкается о собственные лапы. Следует за мамой в приключениях и учится лазать, глядя на отца. Устав, падает в глубокий сон и видит сны о новых играх.
@@ -115,7 +179,22 @@
     en: Mila
     ru: Мила
   gender: female
-  photo: https://animals-travel.ru/upload/medialibrary/693/693042430520412f7d94b7a6886799c3.jpg
+  photos:
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716336/20250805_175738-bed66c61.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716323/20250805_173157-951fbe3d.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716331/20250805_174300-83274aa6.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716322/20250805_173155-b981b9c5.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716336/20250805_175738-bed66c61.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716340/20250812_161723-c9a8c546.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716334/20250805_175105-29415ac3.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716324/20250805_173325-f7084425.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716330/20250805_174202-c0838213.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716336/20250805_175738-bed66c61.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716330/20250805_174202-c0838213.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716345/20250812_162221-89e4934a.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716340/20250812_161723-c9a8c546.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716343/20250812_162133-6a45fb46.jpg
+    - https://res.cloudinary.com/nikmedoed/image/upload/v1755716327/20250805_174025-d70b8d98.jpg
   description:
     en: Shy tortoiseshell girl with a gentle gaze. Mila prefers hiding behind boxes until she feels safe to approach. She watches over her brother Timka and carefully shares treats with him. After a recent eye infection, she enjoys the extra care and warm compresses.
     ru: Скромная черепаховая кошечка с мягким взглядом. Мила предпочитает прятаться за коробками, пока не почувствует себя в безопасности. Присматривает за братом Тимкой и аккуратно делится с ним лакомствами. После недавнего воспаления глаза особенно ценит заботу и тёплые компрессы.

--- a/layouts/cat-gallery.html
+++ b/layouts/cat-gallery.html
@@ -1,0 +1,18 @@
+{{ define "main" }}
+<section class="section">
+  <div class="container">
+    <div id="cat-gallery" class="grid" data-masonry='{"itemSelector": ".grid-item", "columnWidth": 300, "gutter": 16, "fitWidth": true}'>
+      {{ range $cat := .Site.Data.cats }}
+      <div class="grid-item cat-info" data-cat="{{ $cat.id }}" style="display:none">
+        {{ partial "cat-card.html" (dict "cat" $cat "lang" $.Site.Language.Lang "cats" $.Site.Data.cats "showPhoto" false "wrapper" false) }}
+      </div>
+      {{ end }}
+    </div>
+  </div>
+</section>
+<script>
+window.catsData = {{ .Site.Data.cats | jsonify }};
+</script>
+<script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
+<script src="{{ "/js/cat-gallery.js" | relURL }}"></script>
+{{ end }}

--- a/layouts/cats.html
+++ b/layouts/cats.html
@@ -117,7 +117,7 @@
     <div class="columns is-multiline" id="cats-list">
       {{ $lang := .Site.Language.Lang }}
       {{ range .Site.Data.cats }}
-        {{ partial "cat-card.html" (dict "cat" . "lang" $lang "cats" $.Site.Data.cats) }}
+        {{ partial "cat-card.html" (dict "cat" . "lang" $lang "cats" $.Site.Data.cats "galleryLink" true) }}
       {{ end }}
     </div>
   </div>

--- a/layouts/partials/cat-card.html
+++ b/layouts/partials/cat-card.html
@@ -1,13 +1,26 @@
 {{ $cat := .cat }}
 {{ $lang := .lang }}
 {{ $cats := .cats }}
+{{ $wrapper := .wrapper | default true }}
+{{ $showPhoto := .showPhoto | default true }}
+{{ $galleryLink := .galleryLink | default false }}
+{{ if $wrapper }}
 <div class="column is-12-mobile is-6-tablet is-4-desktop">
+{{ end }}
   <div class="card cat-card" id="cat-{{ $cat.id }}" data-year="{{ substr $cat.birth 0 4 }}" data-birth="{{ $cat.birth }}" data-sterilized="{{ if $cat.sterilized }}yes{{ else }}no{{ end }}" data-treatment="{{ if (index $cat.treatment $lang) }}yes{{ else }}no{{ end }}" data-gender="{{ $cat.gender }}" data-wild="{{ if $cat.wild }}yes{{ else }}no{{ end }}" data-wanderer="{{ if $cat.wanderer }}yes{{ else }}no{{ end }}">
+    {{ if $showPhoto }}
     <div class="card-image">
       <figure class="image is-3by2">
-        <img class="cat-photo" src="{{ index $cat.photos 0 }}" alt="{{ index $cat.name $lang }}">
+        {{ if $galleryLink }}
+        <a href="{{ (printf "/cat-gallery/?id=%s" $cat.id) | relLangURL }}">
+          <img class="cat-photo" src="{{ index $cat.photos 0 }}" alt="{{ index $cat.name $lang }}">
+        </a>
+        {{ else }}
+          <img class="cat-photo" src="{{ index $cat.photos 0 }}" alt="{{ index $cat.name $lang }}">
+        {{ end }}
       </figure>
     </div>
+    {{ end }}
     <div class="card-content">
       <div class="is-flex is-align-items-center is-justify-content-space-between mb-2">
         <div class="is-flex is-align-items-center">
@@ -71,5 +84,7 @@
       <a class="card-footer-item adopt-btn" data-name="{{ index $cat.name $lang }}">{{ i18n "adoptButton" }}</a>
     </footer>
   </div>
+{{ if $wrapper }}
 </div>
+{{ end }}
 

--- a/layouts/partials/cat-card.html
+++ b/layouts/partials/cat-card.html
@@ -5,7 +5,7 @@
   <div class="card cat-card" id="cat-{{ $cat.id }}" data-year="{{ substr $cat.birth 0 4 }}" data-birth="{{ $cat.birth }}" data-sterilized="{{ if $cat.sterilized }}yes{{ else }}no{{ end }}" data-treatment="{{ if (index $cat.treatment $lang) }}yes{{ else }}no{{ end }}" data-gender="{{ $cat.gender }}" data-wild="{{ if $cat.wild }}yes{{ else }}no{{ end }}" data-wanderer="{{ if $cat.wanderer }}yes{{ else }}no{{ end }}">
     <div class="card-image">
       <figure class="image is-3by2">
-        <img class="cat-photo" src="{{ $cat.photo }}" alt="{{ index $cat.name $lang }}">
+        <img class="cat-photo" src="{{ index $cat.photos 0 }}" alt="{{ index $cat.name $lang }}">
       </figure>
     </div>
     <div class="card-content">

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -38,6 +38,21 @@ html, body {
   inherits: false;
 }
 
+/* Cat gallery */
+.grid {
+  margin: 0 auto;
+}
+
+.grid-item {
+  width: 300px;
+  margin-bottom: 16px;
+}
+
+.grid-item img {
+  width: 100%;
+  display: block;
+}
+
 @property --wave {
   syntax: "<length>";
   initial-value: 0px;

--- a/static/js/cat-gallery.js
+++ b/static/js/cat-gallery.js
@@ -1,0 +1,27 @@
+document.addEventListener('DOMContentLoaded', function () {
+  const params = new URLSearchParams(window.location.search);
+  const id = params.get('id');
+  if (!id) return;
+  const cats = window.catsData || [];
+  const cat = cats.find(c => c.id === id);
+  if (!cat) return;
+  const grid = document.getElementById('cat-gallery');
+  const info = grid.querySelector(`.cat-info[data-cat="${id}"]`);
+  if (info) info.style.display = '';
+  const lang = document.documentElement.lang || 'en';
+  cat.photos.forEach(url => {
+    const item = document.createElement('div');
+    item.className = 'grid-item';
+    const img = document.createElement('img');
+    img.src = url;
+    img.alt = cat.name && cat.name[lang] ? cat.name[lang] : '';
+    item.appendChild(img);
+    grid.appendChild(item);
+  });
+  new Masonry(grid, {
+    itemSelector: '.grid-item',
+    columnWidth: 300,
+    gutter: 16,
+    fitWidth: true
+  });
+});


### PR DESCRIPTION
## Summary
- allow cat card to load the first photo from a new `photos` array
- seed each cat with a collection of sample photo URLs

## Testing
- `python - <<'PY'
import yaml
with open('data/cats.yaml') as f:
    data=yaml.safe_load(f)
print(len(data))
for cat in data:
    assert 'photos' in cat and isinstance(cat['photos'], list)
print('ok')
PY`
- `hugo`

------
https://chatgpt.com/codex/tasks/task_e_68a642c6409883268025efbbc0ad5d81