### PR TITLE
Add masonry-based gallery for cat photos

### DIFF
--- a/content/gallery.en.md
+++ b/content/gallery.en.md
@@ -1,0 +1,5 @@
+---
+title: Cat Gallery
+url: /cats/gallery/
+layout: cat-gallery
+---

--- a/content/gallery.ru.md
+++ b/content/gallery.ru.md
@@ -1,0 +1,5 @@
+---
+title: Фотогалерея
+url: /ru/cats/gallery/
+layout: cat-gallery
+---

--- a/layouts/cat-gallery.html
+++ b/layouts/cat-gallery.html
@@ -1,0 +1,16 @@
+{{ define "main" }}
+<section class="section cat-gallery">
+  <div class="container">
+    <div class="grid"></div>
+  </div>
+</section>
+<script>
+{{ $cats := dict }}
+{{ range .Site.Data.cats }}
+  {{ $cats = merge $cats (dict .id .) }}
+{{ end }}
+window.cats = {{ $cats | jsonify }};
+</script>
+<script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
+<script src="/js/cat-gallery.js"></script>
+{{ end }}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -164,6 +164,7 @@ html, body {
   width: 100%;
   height: 100%;
   object-fit: cover;
+  cursor: pointer;
 }
 .cat-card.highlight {
   box-shadow: 0 0 0 3px #ffdd57;
@@ -646,4 +647,24 @@ html[data-theme='light'] footer.footer a {
 }
 html[data-theme='light'] footer.footer .has-text-white {
   color: inherit !important;
+}
+
+/* Cat gallery */
+.cat-gallery .grid {
+  margin-top: 1rem;
+}
+
+.cat-gallery .grid-sizer,
+.cat-gallery .grid-item {
+  width: 33.333%;
+}
+
+.cat-gallery .grid-item {
+  padding: 0.5rem;
+}
+
+.cat-gallery .grid-item img {
+  width: 100%;
+  height: auto;
+  display: block;
 }

--- a/static/js/cat-gallery.js
+++ b/static/js/cat-gallery.js
@@ -1,0 +1,75 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const params = new URLSearchParams(location.search);
+  const id = params.get('id');
+  if (!id || !window.cats || !window.cats[id]) return;
+
+  const lang = document.documentElement.lang;
+  const cat = window.cats[id];
+
+  document.title = cat.name[lang];
+
+  const grid = document.querySelector('.grid');
+  if (!grid) return;
+
+  const sizer = document.createElement('div');
+  sizer.className = 'grid-sizer';
+  grid.appendChild(sizer);
+
+  function ageString(birth) {
+    if (!birth) return '';
+    const [year, month] = birth.split('-').map(Number);
+    const now = new Date();
+    let y = now.getFullYear() - year;
+    let m = now.getMonth() + 1 - month;
+    if (m < 0) {
+      y--;
+      m += 12;
+    }
+    const yLabel = lang === 'ru' ? 'г.' : 'y';
+    const mLabel = lang === 'ru' ? 'мес.' : 'm';
+    return `${y} ${yLabel} ${m} ${mLabel}`;
+  }
+
+  function infoCardHTML() {
+    const name = cat.name[lang];
+    const genderIcon = cat.gender === 'male' ? 'fa-mars has-text-link' : 'fa-venus has-text-danger';
+    const sterText = cat.sterilized ? (lang === 'ru' ? 'Стерилизован' : 'Sterilized') : (lang === 'ru' ? 'Не стерилизован' : 'Not sterilized');
+    const sterClass = cat.sterilized ? 'is-success' : 'is-warning';
+    const wildIcon = cat.wild ? '<span class="icon is-medium cat-flag mr-2" tabindex="0"><i class="fa-solid fa-explosion fa-lg"></i></span>' : '';
+    const wandererIcon = cat.wanderer ? '<span class="icon is-medium cat-flag mr-2" tabindex="0"><i class="fas fa-route fa-lg"></i></span>' : '';
+    const parents = (cat.parents || []).map(pid => {
+      const p = window.cats[pid];
+      if (!p) return '';
+      const icon = p.gender === 'male' ? 'fa-mars has-text-link' : 'fa-venus has-text-danger';
+      return `<a class="tag is-light ${p.gender === 'male' ? 'is-link' : 'is-danger'} cat-relative ml-1" href="?id=${p.id}"><span class="icon is-small mr-1"><i class="fas ${icon}"></i></span><span>${p.name[lang]}</span></a>`;
+    }).join('');
+    const parentsBlock = parents ? `<div class="mt-1"><span class="has-text-weight-semibold">${lang==='ru' ? 'Родители:' : 'Parents:'}</span>${parents}</div>` : '';
+    const children = Object.values(window.cats).filter(c => (c.parents || []).includes(cat.id)).map(ch => {
+      const icon = ch.gender === 'male' ? 'fa-mars has-text-link' : 'fa-venus has-text-danger';
+      return `<a class="tag is-light ${ch.gender === 'male' ? 'is-link' : 'is-danger'} cat-relative ml-1" href="?id=${ch.id}"><span class="icon is-small mr-1"><i class="fas ${icon}"></i></span><span>${ch.name[lang]}</span></a>`;
+    }).join('');
+    const childrenBlock = children ? `<div class="mt-1"><span class="has-text-weight-semibold">${lang==='ru' ? 'Дети:' : 'Children:'}</span>${children}</div>` : '';
+    const treatment = cat.treatment && cat.treatment[lang] ? `<div class="tags bottom-tags mt-2"><span class="tag is-danger">${cat.treatment[lang]}</span></div>` : '';
+    const adoptText = lang === 'ru' ? 'Забрать' : 'Adopt';
+    return `<div class="card cat-card"><div class="card-content"><div class="is-flex is-align-items-center is-justify-content-space-between mb-2"><div class="is-flex is-align-items-center"><p class="title is-5 mb-0">${name}</p><span class="icon cat-gender ml-2"><i class="fas ${genderIcon}"></i></span><span class="tag is-rounded is-hoverable cat-ster-tag ml-2 ${sterClass}">${sterText}</span></div><div class="is-flex is-align-items-center">${wildIcon}${wandererIcon}<p class="is-size-7 mb-0 cat-age">${ageString(cat.birth)}</p></div></div><p class="content mb-0">${cat.description[lang]}</p>${parentsBlock}${childrenBlock}${treatment}</div><footer class="card-footer"><a class="card-footer-item adopt-btn" data-name="${name}">${adoptText}</a></footer></div>`;
+  }
+
+  const infoItem = document.createElement('div');
+  infoItem.className = 'grid-item';
+  infoItem.innerHTML = infoCardHTML();
+  grid.appendChild(infoItem);
+
+  cat.photos.forEach(url => {
+    const item = document.createElement('div');
+    item.className = 'grid-item';
+    item.innerHTML = `<figure class="image"><img src="${url}" alt="${cat.name[lang]}"></figure>`;
+    grid.appendChild(item);
+  });
+
+  new Masonry(grid, {
+    itemSelector: '.grid-item',
+    columnWidth: '.grid-sizer',
+    gutter: 10,
+    percentPosition: true
+  });
+});

--- a/static/js/cats.js
+++ b/static/js/cats.js
@@ -127,6 +127,15 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     });
 
+    cards.forEach(card => {
+        const img = card.querySelector('img.cat-photo');
+        if (!img) return;
+        img.addEventListener('click', () => {
+            const id = card.id.replace('cat-', '');
+            location.href = `gallery/?id=${id}`;
+        });
+    });
+
     document.querySelectorAll('.cat-relative').forEach(tag => {
         tag.addEventListener('click', () => {
             const id = tag.dataset.target;


### PR DESCRIPTION
## Summary
- open a per-cat gallery when clicking a card photo
- layout/JS for masonry grid of cat info and photos
- styles for gallery grid and clickable photos

## Testing
- `hugo --minify`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a64c909a4c83269785105daae1c943