### PR TITLE
Fix goal progress layout on narrow screens

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -218,6 +218,7 @@ html, body {
   margin-bottom: 0;
 }
 
+
 .goal-item {
   width: 100%;
   align-items: center;
@@ -226,7 +227,7 @@ html, body {
   margin-bottom: 0.5rem;
 }
 
-@media (max-width: 480px) {
+@media (max-width: 589px), (min-width: 768px) and (max-width: 1400px) {
   .goal-item {
     flex-direction: column;
     align-items: stretch !important;


### PR DESCRIPTION
## Summary
- stack goal progress bars below their labels on small screens for better readability

## Testing
- `hugo --minify`

------
https://chatgpt.com/codex/tasks/task_e_68a72f1d305083269f94a36720df0236