### PR TITLE
Fix adopt modal on cat page and add avatar navigation

### DIFF
--- a/layouts/_default/cat-gallery.html
+++ b/layouts/_default/cat-gallery.html
@@ -1,9 +1,51 @@
 {{ define "main" }}
 <section class="section cat-gallery">
   <div class="container">
+    <div class="cat-links is-flex is-flex-wrap-wrap is-justify-content-center mb-4">
+      {{ $lang := .Site.Language.Lang }}
+      {{ range .Site.Data.cats }}
+        <a class="cat-link" href="?id={{ .id }}">
+          <figure class="image is-48x48">
+            <img src="{{ index .photos 0 }}" alt="{{ index .name $lang }}" class="is-rounded">
+          </figure>
+          <span>{{ index .name $lang }}</span>
+        </a>
+      {{ end }}
+    </div>
     <div class="grid"></div>
   </div>
 </section>
+
+<div id="email-modal" class="modal">
+  <div class="modal-background"></div>
+  <div class="modal-content">
+    <form id="contact-form" class="box contact-box">
+      <div class="field">
+        <label class="label has-text-white" for="email">{{ i18n "formYourEmail" }}</label>
+        <div class="control">
+          <input id="email" class="input" type="email" placeholder="{{ i18n "formPlaceholderEmail" }}">
+        </div>
+      </div>
+      <div class="field">
+        <label class="label has-text-white" for="subject">{{ i18n "formSubject" }}</label>
+        <div class="control">
+          <input id="subject" class="input" type="text" placeholder="{{ i18n "formPlaceholderSubject" }}">
+        </div>
+      </div>
+      <div class="field">
+        <label class="label has-text-white" for="message">{{ i18n "formMessage" }}</label>
+        <div class="control">
+          <textarea id="message" class="textarea" placeholder="{{ i18n "formPlaceholderMessage" }}"></textarea>
+        </div>
+      </div>
+      <div class="field mt-2">
+        <button id="send-btn" type="submit" class="button is-link is-fullwidth">{{ i18n "formSend" }}</button>
+      </div>
+    </form>
+  </div>
+  <button class="modal-close is-large" aria-label="close"></button>
+</div>
+
 <script>
 {{ $cats := dict }}
 {{ range .Site.Data.cats }}
@@ -14,4 +56,5 @@ window.cats = {{ $cats | jsonify | safeJS }};
 <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
 <script src="https://unpkg.com/imagesloaded@4/imagesloaded.pkgd.min.js"></script>
 <script src="/js/cat-gallery.js"></script>
+<script src="/js/cats.js"></script>
 {{ end }}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -708,6 +708,32 @@ html[data-theme='light'] footer.footer .has-text-white {
   display: block;
 }
 
+/* Cat switcher */
+.cat-links {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-bottom: 1rem;
+}
+
+.cat-links .cat-link {
+  display: flex;
+  align-items: center;
+  margin: 0.25rem;
+  font-size: 0.75rem;
+}
+
+.cat-links .cat-link img {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.cat-links .cat-link span {
+  margin-left: 0.5rem;
+}
+
 .lightbox {
   position: fixed;
   inset: 0;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -699,7 +699,7 @@ html[data-theme='light'] footer.footer .has-text-white {
 }
 
 .cat-gallery {
-  padding-top: 0;
+  padding-top: 0.5rem;
 }
 
 .cat-gallery .grid-item {
@@ -745,6 +745,9 @@ html[data-theme='light'] footer.footer .has-text-white {
 
 .cat-links .cat-link .image {
   margin: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .cat-links .cat-link span {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -698,6 +698,10 @@ html[data-theme='light'] footer.footer .has-text-white {
   box-sizing: border-box;
 }
 
+.cat-gallery {
+  padding-top: 0;
+}
+
 .cat-gallery .grid-item {
   padding: 0.5rem;
 }
@@ -718,9 +722,18 @@ html[data-theme='light'] footer.footer .has-text-white {
 
 .cat-links .cat-link {
   display: flex;
+  flex-direction: column;
   align-items: center;
   margin: 0.25rem;
   font-size: 0.75rem;
+  color: #fff;
+  text-align: center;
+  text-decoration: none;
+}
+
+.cat-links .cat-link:hover,
+.cat-links .cat-link:visited {
+  color: #fff;
 }
 
 .cat-links .cat-link img {
@@ -730,8 +743,14 @@ html[data-theme='light'] footer.footer .has-text-white {
   object-fit: cover;
 }
 
+.cat-links .cat-link .image {
+  margin: 0;
+}
+
 .cat-links .cat-link span {
-  margin-left: 0.5rem;
+  margin-left: 0;
+  margin-top: 0.25rem;
+  color: #fff;
 }
 
 .lightbox {

--- a/static/js/cats.js
+++ b/static/js/cats.js
@@ -276,7 +276,11 @@ document.addEventListener('DOMContentLoaded', () => {
     if (emailModal) {
         const bg = emailModal.querySelector('.modal-background');
         const closeBtn = emailModal.querySelector('.modal-close');
-        [bg, closeBtn].forEach(el => el && el.addEventListener('click', resetForm));
+        [bg, closeBtn].forEach(el => el && el.addEventListener('click', () => {
+            resetForm();
+            emailModal.classList.remove('is-active');
+            document.documentElement.classList.remove('is-clipped');
+        }));
     }
     const emailBtn = document.getElementById('email-btn');
     if (emailBtn) emailBtn.addEventListener('click', resetForm);

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -244,17 +244,23 @@ document.addEventListener('DOMContentLoaded', () => {
     const sendBtn = document.getElementById('send-btn');
     const emailBtn = document.getElementById('email-btn');
     const emailModal = document.getElementById('email-modal');
-    if (emailBtn && emailModal) {
-        const closeModal = () => {
-            emailModal.classList.remove('is-active');
-            document.documentElement.classList.remove('is-clipped');
-        };
-        emailBtn.addEventListener('click', () => {
-            emailModal.classList.add('is-active');
-            document.documentElement.classList.add('is-clipped');
-        });
-        emailModal.querySelector('.modal-background').addEventListener('click', closeModal);
-        emailModal.querySelector('.modal-close').addEventListener('click', closeModal);
+    function openEmailModal() {
+        if (!emailModal) return;
+        emailModal.classList.add('is-active');
+        document.documentElement.classList.add('is-clipped');
+    }
+    function closeEmailModal() {
+        if (!emailModal) return;
+        emailModal.classList.remove('is-active');
+        document.documentElement.classList.remove('is-clipped');
+    }
+    if (emailModal) {
+        const bg = emailModal.querySelector('.modal-background');
+        const closeBtn = emailModal.querySelector('.modal-close');
+        [bg, closeBtn].forEach(el => el && el.addEventListener('click', closeEmailModal));
+    }
+    if (emailBtn) {
+        emailBtn.addEventListener('click', openEmailModal);
     }
     if (form) {
         form.addEventListener('submit', e => {
@@ -285,10 +291,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     sendBtn.classList.remove('is-loading');
                     sendBtn.disabled = false;
                 }
-                if (emailModal) {
-                    emailModal.classList.remove('is-active');
-                    document.documentElement.classList.remove('is-clipped');
-                }
+                closeEmailModal();
             });
         });
     }


### PR DESCRIPTION
## Summary
- Add modal form and load shared script so the "adopt" button works on cat pages
- Add top row of small avatar links for quick navigation between cats
- Style new avatar links

## Testing
- `hugo --minify`

------
https://chatgpt.com/codex/tasks/task_e_68a72fda9c2c832685794835fe068364