### PR TITLE
Improve cat card header wrapping

### DIFF
--- a/layouts/partials/cat-card.html
+++ b/layouts/partials/cat-card.html
@@ -9,30 +9,38 @@
       </figure>
     </div>
     <div class="card-content">
-      <div class="cat-header mb-2">
-        <div class="cat-left">
-          <div class="cat-name">
+        <div class="cat-header mb-2">
+          <!-- Зона 1: имя + пол -->
+          <div class="cat-left">
             <p class="title is-5 mb-0">{{ index $cat.name $lang }}</p>
             <span class="icon cat-gender ml-2" data-gender="{{ $cat.gender }}">
               <i class="fas {{ if eq $cat.gender "male" }}fa-mars has-text-link{{ else }}fa-venus has-text-danger{{ end }}"></i>
             </span>
           </div>
 
-          <span class="tag is-rounded is-hoverable cat-ster-tag {{ if $cat.sterilized }}is-success{{ else }}is-warning{{ end }}" data-status="{{ if $cat.sterilized }}sterilized{{ else }}intact{{ end }}">
-            {{ if $cat.sterilized }}{{ i18n "filterSterilized" }}{{ else }}{{ i18n "filterNotSterilized" }}{{ end }}
-          </span>
-        </div>
+          <!-- Зона 2: всё остальное (едет целиком) -->
+          <div class="cat-meta">
+            <!-- слева тег -->
+            <span class="tag is-rounded is-hoverable cat-ster-tag {{ if $cat.sterilized }}is-success{{ else }}is-warning{{ end }}" data-status="{{ if $cat.sterilized }}sterilized{{ else }}intact{{ end }}">
+              {{ if $cat.sterilized }}{{ i18n "filterSterilized" }}{{ else }}{{ i18n "filterNotSterilized" }}{{ end }}
+            </span>
 
-        <div class="cat-right">
-          {{ if $cat.wild }}
-            <span class="icon is-medium cat-flag" data-tooltip="{{ i18n "wildTooltip" }}" tabindex="0"><i class="fa-solid fa-explosion fa-lg"></i></span>
-          {{ end }}
-          {{ if $cat.wanderer }}
-            <span class="icon is-medium cat-flag" data-tooltip="{{ i18n "wandererTooltip" }}" tabindex="0"><i class="fas fa-route fa-lg"></i></span>
-          {{ end }}
-          <p class="is-size-7 mb-0 cat-age"></p>
+            <!-- справа иконки + возраст (единый блок) -->
+            <div class="cat-meta-right">
+              {{ if $cat.wild }}
+                <span class="icon is-medium cat-flag" data-tooltip="{{ i18n "wildTooltip" }}" tabindex="0">
+                  <i class="fa-solid fa-explosion fa-lg"></i>
+                </span>
+              {{ end }}
+              {{ if $cat.wanderer }}
+                <span class="icon is-medium cat-flag" data-tooltip="{{ i18n "wandererTooltip" }}" tabindex="0">
+                  <i class="fas fa-route fa-lg"></i>
+                </span>
+              {{ end }}
+              <p class="is-size-7 mb-0 cat-age"></p>
+            </div>
+          </div>
         </div>
-      </div>
 
       <p class="content mb-0">{{ index $cat.description $lang }}</p>
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -311,58 +311,54 @@ html, body {
 }
 
 /* Cat card header with smart wrapping */
+/* Контейнер шапки: 1 строка при норме, 2 строки при нехватке места */
 .cat-card .cat-header{
   display:flex;
   flex-wrap:wrap;
-  align-items:flex-start;
+  align-items:center;
   column-gap:.6rem;
-  row-gap:.45rem;
+  row-gap:.45rem;                /* отступ между строками */
 }
 
+/* Левая зона: имя + пол */
 .cat-card .cat-left{
   display:flex;
-  flex-wrap:wrap;
-  align-items:center;
-  gap:.45rem .6rem;
-  min-width:0;
-  flex:1 1 auto;
-}
-
-.cat-card .cat-name{
-  display:flex;
   align-items:center;
   min-width:0;
+  flex:1 1 auto;                 /* берёт доступное, но ужимается первой */
 }
-
-.cat-card .cat-name .title{
+.cat-card .cat-left .title{
   margin-bottom:0;
   white-space:nowrap;
   overflow:hidden;
-  text-overflow:ellipsis;
+  text-overflow:ellipsis;        /* длинные имена не ломают сетку */
 }
 
+/* Правая зона: ЕДИНЫЙ ЭЛЕМЕНТ, который переезжает целиком */
+.cat-card .cat-meta{
+  display:flex;
+  align-items:center;
+  gap:.5rem;
+  min-width:14rem;               /* порог, ниже которого зона уедет на 2-ю строку */
+  flex:1 1 18rem;                /* на своей строке — растягивается на всю ширину */
+}
+
+/* Тег слева, без навязанных utility-отступов */
 .cat-card .cat-ster-tag{
+  margin-left:0 !important;
   white-space:nowrap;
-  margin-left:0!important;
-  flex:0 0 auto;
 }
 
-.cat-card .cat-right{
+/* Справа: иконки + возраст всегда вместе (одна строка) */
+.cat-card .cat-meta-right{
+  margin-left:auto;              /* прижим вправо ВНУТРИ зоны */
   display:flex;
   align-items:center;
   gap:.4rem;
-  white-space:nowrap;
-  margin-left:auto;
-  flex:0 0 auto;
+  white-space:nowrap;            /* возраст не отрывается от иконок */
 }
-
-.cat-card .cat-flag{
-  line-height:1;
-}
-
-.cat-card .cat-age{
-  white-space:nowrap;
-}
+.cat-card .cat-flag{ line-height:1; }
+.cat-card .cat-age{ white-space:nowrap; }
 
 .project-media {
   position: relative;


### PR DESCRIPTION
## Summary
- refactor cat card header so sterilization tag, flags, and age wrap cleanly onto a second line
- add flex-based CSS to keep tag left and age right while icons shift as space shrinks

## Testing
- `apt-get update`
- `apt-get install -y hugo`
- `hugo`


------
https://chatgpt.com/codex/tasks/task_e_68a76874dff48326b3ce1e5859719e27