### PR TITLE
Allow wrapping of parent and child tags on narrow screens

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -296,6 +296,7 @@ html, body {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
+  gap: 0.25rem;
 }
 
 #cat-filters .tag {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -295,6 +295,7 @@ html, body {
 .cat-card .card-content > .mt-1 {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
 }
 
 #cat-filters .tag {


### PR DESCRIPTION
## Summary
- allow parent and child sections in cat cards to wrap onto new lines when screen is narrow

## Testing
- `hugo --minify`

------
https://chatgpt.com/codex/tasks/task_e_68a768eaabec8326968434676dcc34fc