### PR TITLE
Limit cat card header to two lines

### DIFF
--- a/layouts/partials/cat-card.html
+++ b/layouts/partials/cat-card.html
@@ -9,26 +9,35 @@
       </figure>
     </div>
     <div class="card-content">
-      <div class="is-flex is-align-items-center is-justify-content-space-between mb-2">
-        <div class="is-flex is-align-items-center">
+      <div class="cat-header mb-2">
+        <div class="cat-left">
           <p class="title is-5 mb-0">{{ index $cat.name $lang }}</p>
           <span class="icon cat-gender ml-2" data-gender="{{ $cat.gender }}">
             <i class="fas {{ if eq $cat.gender "male" }}fa-mars has-text-link{{ else }}fa-venus has-text-danger{{ end }}"></i>
           </span>
-          <span class="tag is-rounded is-hoverable cat-ster-tag ml-2 {{ if $cat.sterilized }}is-success{{ else }}is-warning{{ end }}" data-status="{{ if $cat.sterilized }}sterilized{{ else }}intact{{ end }}">
+        </div>
+
+        <div class="cat-meta">
+          <span class="tag is-rounded is-hoverable cat-ster-tag {{ if $cat.sterilized }}is-success{{ else }}is-warning{{ end }}"
+                data-status="{{ if $cat.sterilized }}sterilized{{ else }}intact{{ end }}">
             {{ if $cat.sterilized }}{{ i18n "filterSterilized" }}{{ else }}{{ i18n "filterNotSterilized" }}{{ end }}
           </span>
-        </div>
-        <div class="is-flex is-align-items-center">
-          {{ if $cat.wild }}
-          <span class="icon is-medium cat-flag mr-2" data-tooltip="{{ i18n "wildTooltip" }}" tabindex="0"><i class="fa-solid fa-explosion fa-lg"></i></span>
-          {{ end }}
-          {{ if $cat.wanderer }}
-          <span class="icon is-medium cat-flag mr-2" data-tooltip="{{ i18n "wandererTooltip" }}" tabindex="0"><i class="fas fa-route fa-lg"></i></span>
-          {{ end }}
-          <p class="is-size-7 mb-0 cat-age"></p>
+
+          <div class="cat-meta-right">
+            {{ if $cat.wild }}
+              <span class="icon is-medium cat-flag" data-tooltip="{{ i18n "wildTooltip" }}" tabindex="0">
+                <i class="fa-solid fa-explosion fa-lg"></i>
+              </span>
+            {{ end }}
+            {{ if $cat.wanderer }}
+              <span class="icon is-medium cat-flag" data-tooltip="{{ i18n "wandererTooltip" }}" tabindex="0">
+                <i class="fas fa-route fa-lg"></i>
+              </span>
+            {{ end }}
+            <p class="is-size-7 mb-0 cat-age"></p>
           </div>
         </div>
+      </div>
 
       <p class="content mb-0">{{ index $cat.description $lang }}</p>
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -312,6 +312,55 @@ html, body {
   padding: 0 0.5em;
 }
 
+/* Container header: max 2 lines */
+.cat-card .cat-header{
+  display:flex;
+  flex-wrap:wrap;
+  align-items:center;
+  column-gap:.6rem;
+  row-gap:.45rem;
+}
+
+/* Line 1: name + gender — no wrap */
+.cat-card .cat-left{
+  display:flex;
+  align-items:center;
+  min-width:0;
+  flex:1 1 auto;
+}
+.cat-card .cat-left .title{
+  margin-bottom:0;
+  white-space:nowrap;
+  overflow:hidden;
+  text-overflow:ellipsis;
+}
+
+/* Line 2: all remaining info moves together */
+.cat-card .cat-meta{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:.5rem;
+  flex:1 1 18rem;
+  min-width:16rem;
+  white-space:nowrap;
+}
+
+/* Sterilization tag: no forced margin */
+.cat-card .cat-ster-tag{
+  margin-left:0 !important;
+}
+
+/* Right subblock: icons + age stay together */
+.cat-card .cat-meta-right{
+  display:flex;
+  align-items:center;
+  gap:.4rem;
+  white-space:nowrap;
+}
+.cat-card .cat-flag{ line-height:1; }
+.cat-card .cat-age{ white-space:nowrap; }
+
 .project-media {
   position: relative;
   overflow: hidden;


### PR DESCRIPTION
## Summary
- Restructure cat card header to show name/gender on the first line and move tag, flags, and age into a second block
- Add styles enforcing two-line layout and keeping icons and age together

## Testing
- `hugo --minify`

------
https://chatgpt.com/codex/tasks/task_e_68a77c921eb08326a1b8c8674ae29467