### PR TITLE
Support multiple treatments and add new cat templates

### DIFF
--- a/data/cats.yaml
+++ b/data/cats.yaml
@@ -408,42 +408,42 @@
     en: []
     ru: []
 
-- id: boyarin
-  name:
-    en: Boyarin
-    ru: "Боярин"
-  gender: male
-  avatar: https://placehold.co/400?text=No+Photo
-  photos: []
-  description:
-    en: Independent and self-sufficient tomcat who likes chasing youngsters.
-    ru: "Деловой, самодостаточный котяра. Любит гонять молодняк."
-  birth: 2022-01
-  sterilized: false
-  wild: true
-  wanderer: true
-  parents: []
-  treatment:
-    en: []
-    ru: []
-
-- id: kuzmich
-  name:
-    en: Kuzmich
-    ru: "Кузьмич"
-  gender: male
-  avatar: https://placehold.co/400?text=No+Photo
-  photos: []
-  description:
-    en: Ginger terror of the neighborhood, marks every corner and fights with pleasure. Surprisingly friendly and allows petting.
-    ru: "Рыжая гроза района, метит каждый угол территории, гоняет котов и дерется с ними с большим удовольствием. При этом на удивление ручной, разрешает себя гладить."
-  birth: 2021-01
-  sterilized: true
-  wild: false
-  wanderer: true
-  parents: []
-  treatment:
-    en:
-      - Battle scars
-    ru:
-      - "боевые шрамы"
+#- id: boyarin
+#  name:
+#    en: Boyarin
+#    ru: "Боярин"
+#  gender: male
+#  avatar: https://placehold.co/400?text=No+Photo
+#  photos: []
+#  description:
+#    en: Independent and self-sufficient tomcat who likes chasing youngsters.
+#    ru: "Деловой, самодостаточный котяра. Любит гонять молодняк."
+#  birth: 2022-01
+#  sterilized: false
+#  wild: true
+#  wanderer: true
+#  parents: []
+#  treatment:
+#    en: []
+#    ru: []
+#
+#- id: kuzmich
+#  name:
+#    en: Kuzmich
+#    ru: "Кузьмич"
+#  gender: male
+#  avatar: https://placehold.co/400?text=No+Photo
+#  photos: []
+#  description:
+#    en: Ginger terror of the neighborhood, marks every corner and fights with pleasure. Surprisingly friendly and allows petting.
+#    ru: "Рыжая гроза района, метит каждый угол территории, гоняет котов и дерется с ними с большим удовольствием. При этом на удивление ручной, разрешает себя гладить."
+#  birth: 2021-01
+#  sterilized: true
+#  wild: false
+#  wanderer: true
+#  parents: []
+#  treatment:
+#    en:
+#      - Battle scars
+#    ru:
+#      - "боевые шрамы"

--- a/data/cats.yaml
+++ b/data/cats.yaml
@@ -338,5 +338,112 @@
   wanderer: false
   parents: []
   treatment:
-    en: Nerve damaged in front leg. Possible ringworm.
-    ru: На передней ноге перекушен нерв. Возможен лишай.
+    en:
+      - Nerve damaged in front leg
+      - Possible ringworm
+    ru:
+      - На передней ноге перекушен нерв
+      - Возможен лишай
+
+- id: sevuk-son-1
+  name:
+    en: Sevuk Son 1
+    ru: "Сын Севук 1"
+  gender: male
+  avatar: https://placehold.co/400?text=No+Photo
+  photos: []
+  description:
+    en: Fluffiest of the kittens, loves to eat and play.
+    ru: "Самый пушистый среди котят, обожает кушать и играть."
+  birth: 2025-07
+  sterilized: false
+  wild: false
+  wanderer: false
+  parents:
+    - sevuk
+    - archi
+  treatment:
+    en: []
+    ru: []
+
+- id: sevuk-son-2
+  name:
+    en: Sevuk Son 2
+    ru: "Сын Севук 2"
+  gender: male
+  avatar: https://placehold.co/400?text=No+Photo
+  photos: []
+  description:
+    en: Most active and brave of all kittens. Very social and loves to eat.
+    ru: "Самый активный и смелый среди всех малышей. Очень контактный, обожает есть."
+  birth: 2025-07
+  sterilized: false
+  wild: false
+  wanderer: false
+  parents:
+    - sevuk
+    - archi
+  treatment:
+    en: []
+    ru: []
+
+- id: sevuk-son-3
+  name:
+    en: Sevuk Son 3
+    ru: "Сын Севук 3"
+  gender: male
+  avatar: https://placehold.co/400?text=No+Photo
+  photos: []
+  description:
+    en: The cleanest of the kittens. Eats well and is very friendly.
+    ru: "Самый чистоплотный среди малышей. Хорошо ест, ручной."
+  birth: 2025-07
+  sterilized: false
+  wild: false
+  wanderer: false
+  parents:
+    - sevuk
+    - archi
+  treatment:
+    en: []
+    ru: []
+
+- id: boyarin
+  name:
+    en: Boyarin
+    ru: "Боярин"
+  gender: male
+  avatar: https://placehold.co/400?text=No+Photo
+  photos: []
+  description:
+    en: Independent and self-sufficient tomcat who likes chasing youngsters.
+    ru: "Деловой, самодостаточный котяра. Любит гонять молодняк."
+  birth: 2022-01
+  sterilized: false
+  wild: true
+  wanderer: true
+  parents: []
+  treatment:
+    en: []
+    ru: []
+
+- id: kuzmich
+  name:
+    en: Kuzmich
+    ru: "Кузьмич"
+  gender: male
+  avatar: https://placehold.co/400?text=No+Photo
+  photos: []
+  description:
+    en: Ginger terror of the neighborhood, marks every corner and fights with pleasure. Surprisingly friendly and allows petting.
+    ru: "Рыжая гроза района, метит каждый угол территории, гоняет котов и дерется с ними с большим удовольствием. При этом на удивление ручной, разрешает себя гладить."
+  birth: 2021-01
+  sterilized: true
+  wild: false
+  wanderer: true
+  parents: []
+  treatment:
+    en:
+      - Battle scars
+    ru:
+      - "боевые шрамы"

--- a/layouts/partials/cat-card.html
+++ b/layouts/partials/cat-card.html
@@ -65,7 +65,7 @@
       {{ $t := index $cat.treatment $lang }}
       {{ if $t }}
       <div class="tags bottom-tags mt-2">
-        {{ if (kindIs "slice" $t) }}
+        {{ if (reflect.IsSlice $t) }}
           {{ range $t }}
           <span class="tag is-danger">{{ . }}</span>
           {{ end }}

--- a/layouts/partials/cat-card.html
+++ b/layouts/partials/cat-card.html
@@ -65,7 +65,13 @@
       {{ $t := index $cat.treatment $lang }}
       {{ if $t }}
       <div class="tags bottom-tags mt-2">
-        <span class="tag is-danger">{{ $t }}</span>
+        {{ if (kindIs "slice" $t) }}
+          {{ range $t }}
+          <span class="tag is-danger">{{ . }}</span>
+          {{ end }}
+        {{ else }}
+          <span class="tag is-danger">{{ $t }}</span>
+        {{ end }}
       </div>
       {{ end }}
     </div>

--- a/static/js/cat-gallery.js
+++ b/static/js/cat-gallery.js
@@ -50,7 +50,8 @@ document.addEventListener('DOMContentLoaded', () => {
         return `<a class="tag is-light ${ch.gender === 'male' ? 'is-link' : 'is-danger'} cat-relative ml-1" href="?id=${ch.id}"><span class="icon is-small mr-1"><i class="fas ${icon}"></i></span><span>${ch.name[lang]}</span></a>`;
       }).join('');
     const childrenBlock = children ? `<div class="mt-1"><span class="has-text-weight-semibold">${lang==='ru' ? 'Дети:' : 'Children:'}</span>${children}</div>` : '';
-    const treatment = cat.treatment && cat.treatment[lang] ? `<div class="tags bottom-tags mt-2"><span class="tag is-danger">${cat.treatment[lang]}</span></div>` : '';
+    const issues = cat.treatment && cat.treatment[lang] ? (Array.isArray(cat.treatment[lang]) ? cat.treatment[lang] : [cat.treatment[lang]]) : [];
+    const treatment = issues.length ? `<div class="tags bottom-tags mt-2">${issues.map(t => `<span class="tag is-danger">${t}</span>`).join('')}</div>` : '';
     const adoptText = lang === 'ru' ? 'Забрать' : 'Adopt';
     return `<div class="card cat-card"><div class="card-content"><div class="is-flex is-align-items-center is-justify-content-space-between mb-2"><div class="is-flex is-align-items-center"><p class="title is-5 mb-0">${name}</p><span class="icon cat-gender ml-2"><i class="fas ${genderIcon}"></i></span><span class="tag is-rounded is-hoverable cat-ster-tag ml-2 ${sterClass}">${sterText}</span></div><div class="is-flex is-align-items-center">${wildIcon}${wandererIcon}<p class="is-size-7 mb-0 cat-age">${ageString(cat.birth)}</p></div></div><p class="content mb-0">${cat.description[lang]}</p>${parentsBlock}${childrenBlock}${treatment}</div><footer class="card-footer"><a class="card-footer-item adopt-btn" data-name="${name}">${adoptText}</a></footer></div>`;
   }


### PR DESCRIPTION
## Summary
- Allow cats to list multiple health issues and display each as a tag
- Add placeholder data for Sevuk's three sons plus Boyarin and Kuzmich

## Testing
- `hugo --minify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b69a09bc8326a41874dd8604363a