### PR TITLE
Fix single cat page sorting error

### DIFF
--- a/static/js/cats.js
+++ b/static/js/cats.js
@@ -65,6 +65,7 @@ document.addEventListener('DOMContentLoaded', () => {
     let sortAsc = false;
     function sortCards() {
         const list = document.getElementById('cats-list');
+        if (!list) return;
         const sorted = cards.slice().sort((a, b) => {
             const [ay, am] = a.dataset.birth.split('-').map(Number);
             const [by, bm] = b.dataset.birth.split('-').map(Number);


### PR DESCRIPTION
## Summary
- prevent cat list sorting when no list exists

## Testing
- `npm test` *(fails: Could not read package.json)*
- `hugo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b72cac988326b2656f32eaca024b