### PR TITLE
Fix donation text visibility on light theme

### DIFF
--- a/layouts/cats.html
+++ b/layouts/cats.html
@@ -37,7 +37,7 @@
           </div>
           <div id="goals-content"></div>
         </div>
-        <div class="box support-box has-text-white has-text-centered mt-4">
+        <div class="box support-box has-text-centered mt-4">
           <p>{{ i18n "catsSupportText" }}</p>
           <div class="buttons is-centered mt-2">
             <a class="button boosty" href="https://boosty.to/nansencats/donate" target="_blank">Boosty 🌍</a>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -50,7 +50,7 @@
             </div>
             <div class="column">
                 <h2 class="title has-text-centered has-text-warning mb-4">{{ i18n "supportTitle" }}</h2>
-                <div class="box support-box has-text-white has-text-centered">
+                <div class="box support-box has-text-centered">
                     <p>{{ i18n "supportText" }}</p>
                     <div class="buttons is-centered mt-2">
                         <a class="button ko-fi" href="https://ko-fi.com/nikmedoed" target="_blank">Ko-fi 🌍</a>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -564,6 +564,7 @@ body.no-scroll {
   position: relative;
   overflow: hidden;
   z-index: 0;
+  color: #fff;
 }
 
 .support-box::before {
@@ -727,6 +728,9 @@ html[data-theme='light'] footer.footer a {
 }
 html[data-theme='light'] footer.footer .has-text-white {
   color: inherit !important;
+}
+html[data-theme='light'] .goal-progress span {
+  color: #000;
 }
 
 /* Cat gallery */


### PR DESCRIPTION
## Summary
- avoid forcing white text on donation support boxes
- ensure progress text switches to dark color in light theme

## Testing
- `hugo --minify`


------
https://chatgpt.com/codex/tasks/task_e_68a8c63580488326a4faa492c550b57d