### PR TITLE
fix: update base URL for custom domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository contains the source for my personal landing page and portfolio.
 The site is generated with **Hugo** using Bulma for styling and a small dark/vivid palette.
 
-Visit the site here: <https://nikmedoed.github.io>
+Visit the site here: <https://nikmedoed.com>
 
 Main page features:
 

--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = "https://nikmedoed.github.io/"
+baseURL = "https://nikmedoed.com/"
 defaultContentLanguage = "en"
 # Default language for the site
 languageCode = "en"


### PR DESCRIPTION
## Summary
- point site base URL to nikmedoed.com to match deployed domain
- update README link to new domain

## Testing
- `hugo --gc --minify`


------
https://chatgpt.com/codex/tasks/task_e_68a8e659e1348326b3b186aedecd1576