### PR TITLE
Group footer links onto new line

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -104,10 +104,12 @@
 <footer class="footer has-background-black has-text-centered has-text-white">
     <p class="is-italic mb-2">{{ i18n "footerQuote" }}</p>
     <p>&copy; 2025 Nikita Muromtsev.
-        <a href="https://github.com/nikmedoed" target="_blank" class="has-text-warning">GitHub</a> |
-        <a href="https://www.linkedin.com/in/muromcevn" target="_blank" class="has-text-warning">LinkedIn</a> |
-        <a href="https://www.instagram.com/nikmedoed/" target="_blank" class="has-text-warning">Instagram</a> |
-        <a href="https://t.me/etonikmedoed" target="_blank" class="has-text-warning">Telegram</a>
+        <span class="footer-links">
+            <a href="https://github.com/nikmedoed" target="_blank" class="has-text-warning">GitHub</a> |
+            <a href="https://www.linkedin.com/in/muromcevn" target="_blank" class="has-text-warning">LinkedIn</a> |
+            <a href="https://www.instagram.com/nikmedoed/" target="_blank" class="has-text-warning">Instagram</a> |
+            <a href="https://t.me/etonikmedoed" target="_blank" class="has-text-warning">Telegram</a>
+        </span>
     </p>
 </footer>
 <script src="/js/script.js"></script>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -492,6 +492,10 @@ body.no-scroll {
   font-weight: 600;
 }
 
+.footer-links {
+  display: inline-block;
+}
+
 #about {
   padding-bottom: 3rem;
 }


### PR DESCRIPTION
## Summary
- Wrap footer links in a span so they move together to the next line when needed
- Add inline-block styling for the link group

## Testing
- `hugo`


------
https://chatgpt.com/codex/tasks/task_e_68a98ac7e5ec8326a27ff9519cd4d378