### PR TITLE
Optimize cat page media loading

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -25,6 +25,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bulma@1.0.0/css/bulma.min.css" rel="stylesheet">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" rel="stylesheet">
     <link href="/css/style.css" rel="stylesheet">
+    {{ block "extra_head" . }}{{ end }}
     <link rel="icon" type="image/png" href="/favicon/favicon-96x96.png" sizes="96x96">
     <link rel="icon" type="image/svg+xml" href="/favicon/favicon.svg">
     <link rel="shortcut icon" href="/favicon/favicon.ico">

--- a/layouts/_default/cats.html
+++ b/layouts/_default/cats.html
@@ -1,4 +1,7 @@
 {{/* cats layout lives in _default for Hugo lookup */}}
+{{ define "extra_head" }}
+<link rel="preload" as="image" href="https://res.cloudinary.com/nikmedoed/image/upload/w_1200/v1755716393/20250813_195232-3293dadb.jpg" fetchpriority="high">
+{{ end }}
 {{ define "main" }}
 {{ $cats := .Site.Data.cats }}
 {{ $current := slice }}

--- a/layouts/partials/cat-card.html
+++ b/layouts/partials/cat-card.html
@@ -5,7 +5,9 @@
   <div class="card cat-card{{ if $cat.location }} adopted{{ end }}" id="cat-{{ $cat.id }}" data-year="{{ substr $cat.birth 0 4 }}" data-birth="{{ $cat.birth }}" {{ if $cat.end }}data-end="{{ $cat.end }}"{{ end }} data-sterilized="{{ if $cat.sterilized }}yes{{ else }}no{{ end }}" data-treatment="{{ if (index $cat.treatment $lang) }}yes{{ else }}no{{ end }}" data-gender="{{ $cat.gender }}" data-wild="{{ if $cat.wild }}yes{{ else }}no{{ end }}" data-wanderer="{{ if $cat.wanderer }}yes{{ else }}no{{ end }}">
     <div class="card-image">
       <figure class="image is-3by2">
-        <img class="cat-photo" src="{{ index $cat.photos 0 }}" alt="{{ index $cat.name $lang }}">
+        {{ $photo := index $cat.photos 0 }}
+        {{ $optimized := replace $photo "/upload/" "/upload/w_716/" }}
+        <img class="cat-photo" src="{{ $optimized }}" alt="{{ index $cat.name $lang }}" loading="lazy" width="358" height="239">
       </figure>
     </div>
     <div class="card-content">

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -77,7 +77,7 @@ html, body {
 
 .cats-hero {
   position: relative;
-  background-image: url('https://res.cloudinary.com/nikmedoed/image/upload/v1755716393/20250813_195232-3293dadb.jpg');
+  background-image: url('https://res.cloudinary.com/nikmedoed/image/upload/w_1200/v1755716393/20250813_195232-3293dadb.jpg');
   background-size: cover;
   background-position: center;
   color: #fff;


### PR DESCRIPTION
## Summary
- Preload optimized hero image on cats page for faster LCP
- Lazy load cat gallery images at reduced resolution
- Allow page-specific head customizations

## Testing
- `hugo`

------
https://chatgpt.com/codex/tasks/task_e_68aa022e767c83269a2a2e83e5cbe601