### PR TITLE
Hide adopt button for wild or wandering cats

### DIFF
--- a/layouts/partials/cat-card.html
+++ b/layouts/partials/cat-card.html
@@ -91,7 +91,7 @@
     </div>
     <footer class="card-footer">
       <a class="card-footer-item" href="gallery/?id={{ $cat.id }}">{{ i18n "moreAbout" (dict "Name" (index $cat.name $lang)) }}</a>
-      {{ if not $cat.end }}
+      {{ if and (not $cat.end) (not $cat.wild) (not $cat.wanderer) }}
       <button class="card-footer-item adopt-btn has-text-link" type="button" data-name="{{ index $cat.name $lang }}">{{ i18n "adoptButton" }}</button>
       {{ end }}
     </footer>

--- a/static/js/cat-gallery.js
+++ b/static/js/cat-gallery.js
@@ -54,7 +54,11 @@ document.addEventListener('DOMContentLoaded', () => {
     const issues = cat.treatment && cat.treatment[lang] ? (Array.isArray(cat.treatment[lang]) ? cat.treatment[lang] : [cat.treatment[lang]]) : [];
     const treatment = issues.length ? `<div class="tags bottom-tags mt-2">${issues.map(t => `<span class="tag is-danger">${t}</span>`).join('')}</div>` : '';
     const adoptText = lang === 'ru' ? 'Забрать' : 'Adopt';
-    return `<div class="card cat-card"><div class="card-content"><div class="is-flex is-align-items-center is-justify-content-space-between mb-2"><div class="is-flex is-align-items-center"><p class="title is-5 mb-0">${name}</p><span class="icon cat-gender ml-2"><i class="fas ${genderIcon}"></i></span><span class="tag is-rounded is-hoverable cat-ster-tag ml-2 ${sterClass}">${sterText}</span></div><div class="is-flex is-align-items-center">${wildIcon}${wandererIcon}<p class="is-size-7 mb-0 cat-age">${ageString(cat.birth)}</p></div></div><p class="content mb-0">${cat.description[lang]}</p>${parentsBlock}${childrenBlock}${treatment}</div><footer class="card-footer"><button class="card-footer-item adopt-btn has-text-link" type="button" data-name="${name}">${adoptText}</button></footer></div>`;
+    const adoptBtn = !cat.end && !cat.wild && !cat.wanderer
+      ? `<button class="card-footer-item adopt-btn has-text-link" type="button" data-name="${name}">${adoptText}</button>`
+      : '';
+    const footer = adoptBtn ? `<footer class="card-footer">${adoptBtn}</footer>` : '';
+    return `<div class="card cat-card"><div class="card-content"><div class="is-flex is-align-items-center is-justify-content-space-between mb-2"><div class="is-flex is-align-items-center"><p class="title is-5 mb-0">${name}</p><span class="icon cat-gender ml-2"><i class="fas ${genderIcon}"></i></span><span class="tag is-rounded is-hoverable cat-ster-tag ml-2 ${sterClass}">${sterText}</span></div><div class="is-flex is-align-items-center">${wildIcon}${wandererIcon}<p class="is-size-7 mb-0 cat-age">${ageString(cat.birth)}</p></div></div><p class="content mb-0">${cat.description[lang]}</p>${parentsBlock}${childrenBlock}${treatment}</div>${footer}</div>`;
   }
 
   const infoItem = document.createElement('div');


### PR DESCRIPTION
## Summary
- Hide adopt button in cat cards when a cat is marked wild or wanderer.
- Ensure the cat gallery respects the same rule when rendering a cat's details.

## Testing
- `hugo`

------
https://chatgpt.com/codex/tasks/task_e_68acb30273e88326a605ab9b4e8a971f