### PR TITLE
Enable wrapping for email button text

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -638,6 +638,8 @@ body.no-scroll {
 
 #email-btn {
   width: 12rem;
+  white-space: normal;
+  height: auto;
 }
 
 html[data-theme='light'] #email-btn {


### PR DESCRIPTION
## Summary
- allow the email button text to wrap when it exceeds the fixed width

## Testing
- `hugo --minify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b196e07f688326b2513782611a6e95