### PR TITLE
Fix charity button text overflow on small screens

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -719,6 +719,11 @@ html[data-theme='light'] #email-btn {
   background-color: var(--c-violet);
   border-color: var(--c-violet);
   color: #fff;
+  display: inline-block;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  height: auto;
+  text-align: center;
 }
 
 .hero-buttons .button:hover,


### PR DESCRIPTION
## Summary
- allow charity button text to wrap and stay within the screen on mobile

## Testing
- `hugo -D`


------
https://chatgpt.com/codex/tasks/task_e_68b1a05ddb808326b9727e56d2dde8ee