### PR TITLE
Handle explicit language URLs without redirect

### DIFF
--- a/static/js/script.js
+++ b/static/js/script.js
@@ -9,6 +9,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     const currentLang = document.documentElement.lang;
     const storedLang = localStorage.getItem('lang');
+    const pathHasExplicitLang = /^\/(en|ru)(?:\/|$)/.test(location.pathname);
     const translations = {
         en: {all: 'All', sent: 'Message sent!', fail: 'Failed to send message.'},
         ru: {all: 'Все', sent: 'Сообщение отправлено!', fail: 'Не удалось отправить сообщение.'}
@@ -29,8 +30,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!storedLang) {
         const navLang = (navigator.languages && navigator.languages[0]) || navigator.language || '';
         const detected = navLang.startsWith('ru') ? 'ru' : 'en';
-        if (detected !== currentLang) {
-            localStorage.setItem('lang', detected);
+        if (!pathHasExplicitLang && detected !== currentLang) {
             const target = langPath(detected) + stripLang(location.pathname) + location.search + location.hash;
             if (target !== location.pathname + location.search + location.hash) {
                 location.replace(target);


### PR DESCRIPTION
## Summary
- prevent automatic language detection from redirecting when a language-specific path is visited directly
- avoid persisting auto-detected language in local storage so that only explicit choices are remembered

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d545a0a4c08326bd458eb6c0e6543c